### PR TITLE
Adafruit-GFX-Library - Possible solution for Adafruit_GFX constructor-related link issue

### DIFF
--- a/Adafruit_GFX.cpp
+++ b/Adafruit_GFX.cpp
@@ -18,7 +18,7 @@ All text above must be included in any redistribution
 #include "glcdfont.c"
 #include <avr/pgmspace.h>
 
-void Adafruit_GFX::constructor(int16_t w, int16_t h) {
+Adafruit_GFX::Adafruit_GFX(int16_t w, int16_t h) {
   _width = WIDTH = w;
   _height = HEIGHT = h;
 

--- a/Adafruit_GFX.h
+++ b/Adafruit_GFX.h
@@ -28,12 +28,11 @@ All text above must be included in any redistribution
 class Adafruit_GFX : public Print {
  public:
 
-  //Adafruit_GFX();
-  // i have no idea why we have to formally call the constructor. kinda sux
-  void constructor(int16_t w, int16_t h);
+  Adafruit_GFX(int16_t w, int16_t h);
 
   // this must be defined by the subclass
-  virtual void drawPixel(int16_t x, int16_t y, uint16_t color);
+  virtual void drawPixel(int16_t x, int16_t y, uint16_t color) = 0;
+
   virtual void invertDisplay(boolean i);
 
   // these are 'generic' drawing functions, so we can share them!


### PR DESCRIPTION
Declare Adafruit_GFX::drawPixel pure virtual so that the compiler
knows not to expect a definition of the method in this class. The
compiler appears to create the vtable with the first
non-constructor, non-pure virtual method so when this method is
the first non-constructor method in the class and it is not
declared pure virtual the linker fails to find the vtable for this
class.

Change the Adafruit_GFX::constructor method to a real constructor.
