### PR TITLE
Draw lines as small line segments instead of pixels

### DIFF
--- a/Adafruit_GFX.cpp
+++ b/Adafruit_GFX.cpp
@@ -201,10 +201,11 @@ void Adafruit_GFX::drawLine(int16_t x0, int16_t y0,
       seg=x0+1;
     }
   }
+  // x0 incremented
   if (steep) {
-    drawFastVLine(y0, seg, (x0-seg)+1, color);
+    drawFastVLine(y0, seg, (x0-seg), color);
   } else {
-    drawFastHLine(seg, y0, (x0-seg)+1, color);
+    drawFastHLine(seg, y0, (x0-seg), color);
   }
 }
 


### PR DESCRIPTION
It occurred to me that Bresenham's algorithm walks in the X and periodically steps the Y.
So I modified the algorithm to draw short lines instead of pixels.

The idea is that every time you increase the Y you store the current X, and when the Y is increased again, draw a line from the stored X to the current X.

The lines benchmark on my ILI9341 got about twice as fast, using my optimized fork adafruit/Adafruit_ILI9341#3

```
baseline
Screen fill              1135696
Text                     214436
Lines                    2009244
Horiz/Vert Lines         98852
Rectangles (outline)     68052
Rectangles (filled)      2358700
Circles (filled)         645056
Circles (outline)        877660
Triangles (outline)      637436
Triangles (filled)       1177460
Rounded rects (outline)  306064
Rounded rects (filled)   2665260

line segments
Screen fill              1135696
Text                     214436
Lines                    1065012
Horiz/Vert Lines         98852
Rectangles (outline)     68040
Rectangles (filled)      2358644
Circles (filled)         645060
Circles (outline)        877684
Triangles (outline)      242460
Triangles (filled)       1177452
Rounded rects (outline)  306068
Rounded rects (filled)   2665288
```

However, there is a off-by-one error somewhere. Some lines seem to wrap around the edge of the screen.
I've been staring at it for hours, so I'm just going to submit the pull.

![img_20141003_160056](https://cloud.githubusercontent.com/assets/168609/4506818/ba012a06-4b06-11e4-8454-7de93d63595c.jpg)
