### PR TITLE
Made swap a function to prevent awful error messages from macros.

### DIFF
--- a/Adafruit_GFX.h
+++ b/Adafruit_GFX.h
@@ -8,7 +8,7 @@
  #include "WProgram.h"
 #endif
 
-#define swap(a, b) { int16_t t = a; a = b; b = t; }
+inline void swap(int16_t &a, int16_t &b) { int16_t t = a; a = b; b = t; }
 
 class Adafruit_GFX : public Print {
 


### PR DESCRIPTION
This macro causes a lot of grief for poor students who aren't yet familiar with gcc's dreadful error messages. Unfortunately "swap" is a common name for functions, and if people aren't careful and declare their own functions when including Adafruit_GFX.h you get a misleading error, as opposed to a duplicate declaration one.

To clarify... I have seen this issue manifest itself many times in a university Arduino course! Preferably swap would not be exposed at all, but I worry that somebody might depend upon this.
