### PR TITLE
Added support for multicolor pixmaps in drawRGBBitmap.

### DIFF
--- a/Adafruit_GFX.cpp
+++ b/Adafruit_GFX.cpp
@@ -403,6 +403,20 @@ void Adafruit_GFX::drawXBitmap(int16_t x, int16_t y,
   }
 }
 
+// Draw colored bitmap (each pixel is a uint16_t, with colors defined by
+// the drawpixel method of your graphical backend.
+void Adafruit_GFX::drawRGBBitmap(int16_t x, int16_t y,
+			      const uint16_t *bitmap, int16_t w, int16_t h) {
+  int16_t i, j;
+
+  for(j=0; j<h; j++) {
+    for(i=0; i<w; i++ ) {
+	drawPixel(x+i, y+j, pgm_read_byte(bitmap + j * w + i));
+    }
+  }
+}
+
+
 #if ARDUINO >= 100
 size_t Adafruit_GFX::write(uint8_t c) {
 #else

--- a/Adafruit_GFX.cpp
+++ b/Adafruit_GFX.cpp
@@ -404,14 +404,21 @@ void Adafruit_GFX::drawXBitmap(int16_t x, int16_t y,
 }
 
 // Draw colored bitmap (each pixel is a uint16_t, with colors defined by
+// Draw colored bitmap (each pixel is a uint16_t, with colors defined by
 // the drawpixel method of your graphical backend.
+// progmem defaults to true for bitmaps defined as static const uint16_t PROGMEM
+// but you can set it to false to send a bitmap array in RAM.
 void Adafruit_GFX::drawRGBBitmap(int16_t x, int16_t y,
-			      const uint16_t *bitmap, int16_t w, int16_t h) {
+		const uint16_t *bitmap, int16_t w, int16_t h, bool progmem) {
   int16_t i, j;
 
   for(j=0; j<h; j++) {
     for(i=0; i<w; i++ ) {
-	drawPixel(x+i, y+j, pgm_read_word(bitmap + j * w + i));
+	if (progmem) {
+	  drawPixel(x+i, y+j, pgm_read_word(bitmap + j * w + i));
+	} else {
+	  drawPixel(x+i, y+j, (uint16_t) *(bitmap + j * w + i));
+	}
     }
   }
 }

--- a/Adafruit_GFX.cpp
+++ b/Adafruit_GFX.cpp
@@ -411,7 +411,7 @@ void Adafruit_GFX::drawRGBBitmap(int16_t x, int16_t y,
 
   for(j=0; j<h; j++) {
     for(i=0; i<w; i++ ) {
-	drawPixel(x+i, y+j, pgm_read_byte(bitmap + j * w + i));
+	drawPixel(x+i, y+j, pgm_read_word(bitmap + j * w + i));
     }
   }
 }

--- a/Adafruit_GFX.h
+++ b/Adafruit_GFX.h
@@ -52,6 +52,8 @@ class Adafruit_GFX : public Print {
       int16_t w, int16_t h, uint16_t color, uint16_t bg),
     drawXBitmap(int16_t x, int16_t y, const uint8_t *bitmap, 
       int16_t w, int16_t h, uint16_t color),
+    drawRGBBitmap(int16_t x, int16_t y, const uint16_t *bitmap,
+      int16_t w, int16_t h),
     drawChar(int16_t x, int16_t y, unsigned char c, uint16_t color,
       uint16_t bg, uint8_t size),
     setCursor(int16_t x, int16_t y),

--- a/Adafruit_GFX.h
+++ b/Adafruit_GFX.h
@@ -53,7 +53,7 @@ class Adafruit_GFX : public Print {
     drawXBitmap(int16_t x, int16_t y, const uint8_t *bitmap, 
       int16_t w, int16_t h, uint16_t color),
     drawRGBBitmap(int16_t x, int16_t y, const uint16_t *bitmap,
-      int16_t w, int16_t h),
+      int16_t w, int16_t h,bool progmem=true),
     drawChar(int16_t x, int16_t y, unsigned char c, uint16_t color,
       uint16_t bg, uint8_t size),
     setCursor(int16_t x, int16_t y),


### PR DESCRIPTION
This adds support for multicolor bitmaps as supported by my software PWM matrix driver

![snap1](https://cloud.githubusercontent.com/assets/1369412/5607690/f89239f2-9419-11e4-9b53-ecc7bbdd0b65.jpg)
![snap2](https://cloud.githubusercontent.com/assets/1369412/5607691/f896a8c0-9419-11e4-95ed-c6e8ff39b54f.jpg)
![snap3](https://cloud.githubusercontent.com/assets/1369412/5607692/f89c0fcc-9419-11e4-8e9e-ebca4813e365.jpg)
![](https://raw.githubusercontent.com/marcmerlin/LED-Matrix/master/screenshots/snap3_2.jpg)
