### PR TITLE
Make custom fonts work on ESP8266 as well

### DIFF
--- a/Adafruit_GFX.cpp
+++ b/Adafruit_GFX.cpp
@@ -35,11 +35,14 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "glcdfont.c"
 #ifdef __AVR__
  #include <avr/pgmspace.h>
+ #define pgm_read_pointer(addr) ((void *)pgm_read_word(addr))
 #elif defined(ESP8266)
  #include <pgmspace.h>
+ #define pgm_read_pointer(addr) ((void *)pgm_read_dword(addr))
 #else
  #define pgm_read_byte(addr) (*(const unsigned char *)(addr))
  #define pgm_read_word(addr) (*(const unsigned short *)(addr))
+ #define pgm_read_pointer(addr) ((void *)pgm_read_word(addr))
 #endif
 
 #ifndef min
@@ -474,7 +477,7 @@ void Adafruit_GFX::write(uint8_t c) {
       uint8_t first = pgm_read_byte(&gfxFont->first);
       if((c >= first) && (c <= (uint8_t)pgm_read_byte(&gfxFont->last))) {
         uint8_t   c2    = c - pgm_read_byte(&gfxFont->first);
-        GFXglyph *glyph = &(((GFXglyph *)pgm_read_word(&gfxFont->glyph))[c2]);
+        GFXglyph *glyph = &(((GFXglyph *)pgm_read_pointer(&gfxFont->glyph))[c2]);
         uint8_t   w     = pgm_read_byte(&glyph->width),
                   h     = pgm_read_byte(&glyph->height);
         if((w > 0) && (h > 0)) { // Is there an associated bitmap?
@@ -533,8 +536,8 @@ void Adafruit_GFX::drawChar(int16_t x, int16_t y, unsigned char c,
     // directly with 'bad' characters of font may cause mayhem!
 
     c -= pgm_read_byte(&gfxFont->first);
-    GFXglyph *glyph  = &(((GFXglyph *)pgm_read_word(&gfxFont->glyph))[c]);
-    uint8_t  *bitmap = (uint8_t *)pgm_read_word(&gfxFont->bitmap);
+    GFXglyph *glyph  = &(((GFXglyph *)pgm_read_pointer(&gfxFont->glyph))[c]);
+    uint8_t  *bitmap = (uint8_t *)pgm_read_pointer(&gfxFont->bitmap);
 
     uint16_t bo = pgm_read_word(&glyph->bitmapOffset);
     uint8_t  w  = pgm_read_byte(&glyph->width),
@@ -690,7 +693,7 @@ void Adafruit_GFX::getTextBounds(char *str, int16_t x, int16_t y,
         if(c != '\r') { // Not a carriage return, is normal char
           if((c >= first) && (c <= last)) { // Char present in current font
             c    -= first;
-            glyph = &(((GFXglyph *)pgm_read_word(&gfxFont->glyph))[c]);
+            glyph = &(((GFXglyph *)pgm_read_pointer(&gfxFont->glyph))[c]);
             gw    = pgm_read_byte(&glyph->width);
             gh    = pgm_read_byte(&glyph->height);
             xa    = pgm_read_byte(&glyph->xAdvance);
@@ -779,7 +782,7 @@ void Adafruit_GFX::getTextBounds(const __FlashStringHelper *str,
         if(c != '\r') { // Not a carriage return, is normal char
           if((c >= first) && (c <= last)) { // Char present in current font
             c    -= first;
-            glyph = &(((GFXglyph *)pgm_read_word(&gfxFont->glyph))[c]);
+            glyph = &(((GFXglyph *)pgm_read_pointer(&gfxFont->glyph))[c]);
             gw    = pgm_read_byte(&glyph->width);
             gh    = pgm_read_byte(&glyph->height);
             xa    = pgm_read_byte(&glyph->xAdvance);


### PR DESCRIPTION
It looks to me like the ESP8266 has 32-bit pgm pointers