### PR TITLE
getTextBounds should consider the last line width

### DIFF
--- a/Adafruit_GFX.cpp
+++ b/Adafruit_GFX.cpp
@@ -748,6 +748,7 @@ void Adafruit_GFX::getTextBounds(char *str, int16_t x, int16_t y,
     }
     // End of string
     if(lineWidth) y += textsize * 8; // Add height of last (or only) line
+    if(lineWidth > maxWidth) maxWidth = lineWidth; // Is the last or only line the widest?
     *w = maxWidth - 1;               // Don't include last interchar x gap
     *h = y - *y1;
 
@@ -837,6 +838,7 @@ void Adafruit_GFX::getTextBounds(const __FlashStringHelper *str,
     }
     // End of string
     if(lineWidth) y += textsize * 8; // Add height of last (or only) line
+    if(lineWidth > maxWidth) maxWidth = lineWidth; // Is the last or only line the widest?
     *w = maxWidth - 1;               // Don't include last interchar x gap
     *h = y - *y1;
 


### PR DESCRIPTION
In the default 5x7 font handling, the last line isn't considered when
determining the longest line.  Also, for the same reason, when there is
only one line, getTextBounds returns 65535 as the width.