### PR TITLE
Modify type of SizeText in Adafruit_GFX.cpp 

### DIFF
--- a/Adafruit_GFX.cpp
+++ b/Adafruit_GFX.cpp
@@ -624,7 +624,7 @@ int16_t Adafruit_GFX::getCursorY(void) const {
   return cursor_y;
 }
 
-void Adafruit_GFX::setTextSize(uint8_t s) {
+void Adafruit_GFX::setTextSize(float s) {
   textsize = (s > 0) ? s : 1;
 }
 


### PR DESCRIPTION
Change in function void Adafruit_GFX::setTextSize(uint8_t s) to Adafruit_GFX::setTextSize(float s). 
it's more convenient. 
For small screen if we want some text in medium size we don't have. 
if we choose the size 1 it's too small and size 2 it's too big so if we put a float instead of uint8_t we can choose something like 1.4 , 1.7 and it's more effective. 
Thank's