### PR TITLE
Make it compile on Non-Arduino platforms

### DIFF
--- a/Adafruit_GFX.cpp
+++ b/Adafruit_GFX.cpp
@@ -521,6 +521,13 @@ void Adafruit_GFX::write(uint8_t c) {
 #endif
 }
 
+#ifndef ARDUINO
+void Adafruit_GFX::print(const char *s) {
+  for(; *s != '\0'; s++)
+    write(*s);
+}
+#endif
+
 // Draw a character
 void Adafruit_GFX::drawChar(int16_t x, int16_t y, unsigned char c,
  uint16_t color, uint16_t bg, uint8_t size) {
@@ -778,6 +785,7 @@ void Adafruit_GFX::getTextBounds(char *str, int16_t x, int16_t y,
   } // End classic vs custom font
 }
 
+#ifdef ARDUINO
 // Same as above, but for PROGMEM strings
 void Adafruit_GFX::getTextBounds(const __FlashStringHelper *str,
  int16_t x, int16_t y, int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h) {
@@ -866,6 +874,7 @@ void Adafruit_GFX::getTextBounds(const __FlashStringHelper *str,
 
   } // End classic vs custom font
 }
+#endif
 
 // Return the size of the display (per current rotation)
 int16_t Adafruit_GFX::width(void) const {

--- a/Adafruit_GFX.h
+++ b/Adafruit_GFX.h
@@ -4,13 +4,21 @@
 #if ARDUINO >= 100
  #include "Arduino.h"
  #include "Print.h"
-#else
+#elif defined(ARDUINO)
  #include "WProgram.h"
+#else
+ #include <cstdlib>
+ #include <string.h>
+ typedef bool boolean;
 #endif
 
 #include "gfxfont.h"
 
-class Adafruit_GFX : public Print {
+#ifdef ARDUINO
+ class Adafruit_GFX : public Print {
+#else
+ class Adafruit_GFX {
+#endif
 
  public:
 
@@ -66,15 +74,21 @@ class Adafruit_GFX : public Print {
     setRotation(uint8_t r),
     cp437(boolean x=true),
     setFont(const GFXfont *f = NULL),
-    getTextBounds(char *string, int16_t x, int16_t y,
-      int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h),
+#ifdef ARDUINO
     getTextBounds(const __FlashStringHelper *s, int16_t x, int16_t y,
+      int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h),
+#endif
+    getTextBounds(char *string, int16_t x, int16_t y,
       int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h);
 
 #if ARDUINO >= 100
   virtual size_t write(uint8_t);
 #else
   virtual void   write(uint8_t);
+#endif
+
+#ifndef ARDUINO
+  void print(const char *s);
 #endif
 
   int16_t height(void) const;


### PR DESCRIPTION
I'm working on an Embedded Linux system with a small SPI display and decided to use Adafruit GFX as a simple, light-weight drawing library. (To make it actually do something I will also develop and provide a subclass that writes to a Linux framebuffer.)

In order to make the library compile outside of the Arduino SDK I added a few tweaks to the code. Of course they only come into effect when `ARDUINO` is not defined.

If you'd like to keep your repository Arduino specific that's fine. I just figured a PR couldn't hurt since it's only minor tweaks and someone else might benefit from them at some point. But I can also keep them in my fork if you prefer.
