### PR TITLE
Clear glyph background

### DIFF
--- a/Adafruit_GFX.cpp
+++ b/Adafruit_GFX.cpp
@@ -700,7 +700,7 @@ void Adafruit_GFX::clearChangedGlyph(char *previous, char *current,
 
   getTextBounds(previous, x, y, &x1, &y1, &w, &h, glyphWidths);
 
-  uint8_t cursor_x = x1;
+  uint8_t cursor_x = x;
   for(uint8_t i = 0; i < length; i++) {
     if(previous[i] != current[i]) {
       fillRect(cursor_x, y1, glyphWidths[i], h, color);

--- a/Adafruit_GFX.cpp
+++ b/Adafruit_GFX.cpp
@@ -688,7 +688,8 @@ void Adafruit_GFX::setFont(const GFXfont *f) {
   }
   gfxFont = (GFXfont *)f;
 }
-
+// Takes two char array, checks wich glyph has changed within
+// the current one, and clears the background of just that glyph
 void Adafruit_GFX::clearChangedGlyph(char *previous, char *current, 
   int16_t x, int16_t y, uint16_t color) {
 

--- a/Adafruit_GFX.cpp
+++ b/Adafruit_GFX.cpp
@@ -756,7 +756,7 @@ void Adafruit_GFX::getTextBounds(char *str, int16_t x, int16_t y,
             if(gy2 > maxy) maxy = gy2;
             x += xa * ts;
 
-            *glyphWidths++ = xa * ts;
+            if(glyphWidths != NULL) *glyphWidths++ = xa * ts;
           }
         } // Carriage return = do nothing
       } else { // Newline
@@ -785,7 +785,7 @@ void Adafruit_GFX::getTextBounds(char *str, int16_t x, int16_t y,
           } else { // No line wrap, just keep incrementing X
             lineWidth += textsize * 6; // Includes interchar x gap
           }
-          *glyphWidths++ = textsize * 6;
+          if(glyphWidths != NULL) *glyphWidths++ = textsize * 6;
         } // Carriage return = do nothing
       } else { // Newline
         x  = 0;            // Reset x to 0
@@ -801,94 +801,6 @@ void Adafruit_GFX::getTextBounds(char *str, int16_t x, int16_t y,
   } // End classic vs custom font
 }
 
-// Pass string and a cursor position, returns UL corner and W,H.
-void Adafruit_GFX::getTextBounds(char *str, int16_t x, int16_t y,
- int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h) {
-  uint8_t c; // Current character
-
-  *x1 = x;
-  *y1 = y;
-  *w  = *h = 0;
-
-  if(gfxFont) {
-
-    GFXglyph *glyph;
-    uint8_t   first = pgm_read_byte(&gfxFont->first),
-              last  = pgm_read_byte(&gfxFont->last),
-              gw, gh, xa;
-    int8_t    xo, yo;
-    int16_t   minx = _width, miny = _height, maxx = -1, maxy = -1,
-              gx1, gy1, gx2, gy2, ts = (int16_t)textsize,
-              ya = ts * (uint8_t)pgm_read_byte(&gfxFont->yAdvance);
-
-    while((c = *str++)) {
-      if(c != '\n') { // Not a newline
-        if(c != '\r') { // Not a carriage return, is normal char
-          if((c >= first) && (c <= last)) { // Char present in current font
-            c    -= first;
-            glyph = &(((GFXglyph *)pgm_read_pointer(&gfxFont->glyph))[c]);
-            gw    = pgm_read_byte(&glyph->width);
-            gh    = pgm_read_byte(&glyph->height);
-            xa    = pgm_read_byte(&glyph->xAdvance);
-            xo    = pgm_read_byte(&glyph->xOffset);
-            yo    = pgm_read_byte(&glyph->yOffset);
-            if(wrap && ((x + (((int16_t)xo + gw) * ts)) >= _width)) {
-              // Line wrap
-              x  = 0;  // Reset x to 0
-              y += ya; // Advance y by 1 line
-            }
-            gx1 = x   + xo * ts;
-            gy1 = y   + yo * ts;
-            gx2 = gx1 + gw * ts - 1;
-            gy2 = gy1 + gh * ts - 1;
-            if(gx1 < minx) minx = gx1;
-            if(gy1 < miny) miny = gy1;
-            if(gx2 > maxx) maxx = gx2;
-            if(gy2 > maxy) maxy = gy2;
-            x += xa * ts;
-          }
-        } // Carriage return = do nothing
-      } else { // Newline
-        x  = 0;  // Reset x
-        y += ya; // Advance y by 1 line
-      }
-    }
-    // End of string
-    *x1 = minx;
-    *y1 = miny;
-    if(maxx >= minx) *w  = maxx - minx + 1;
-    if(maxy >= miny) *h  = maxy - miny + 1;
-
-  } else { // Default font
-
-    uint16_t lineWidth = 0, maxWidth = 0; // Width of current, all lines
-
-    while((c = *str++)) {
-      if(c != '\n') { // Not a newline
-        if(c != '\r') { // Not a carriage return, is normal char
-          if(wrap && ((x + textsize * 6) >= _width)) {
-            x  = 0;            // Reset x to 0
-            y += textsize * 8; // Advance y by 1 line
-            if(lineWidth > maxWidth) maxWidth = lineWidth; // Save widest line
-            lineWidth  = textsize * 6; // First char on new line
-          } else { // No line wrap, just keep incrementing X
-            lineWidth += textsize * 6; // Includes interchar x gap
-          }
-        } // Carriage return = do nothing
-      } else { // Newline
-        x  = 0;            // Reset x to 0
-        y += textsize * 8; // Advance y by 1 line
-        if(lineWidth > maxWidth) maxWidth = lineWidth; // Save widest line
-        lineWidth = 0;     // Reset lineWidth for new line
-      }
-    }
-    // End of string
-    if(lineWidth) y += textsize * 8; // Add height of last (or only) line
-    *w = maxWidth - 1;               // Don't include last interchar x gap
-    *h = y - *y1;
-
-  } // End classic vs custom font
-}
 
 // Same as above, but for PROGMEM strings
 void Adafruit_GFX::getTextBounds(const __FlashStringHelper *str,

--- a/Adafruit_GFX.cpp
+++ b/Adafruit_GFX.cpp
@@ -689,6 +689,25 @@ void Adafruit_GFX::setFont(const GFXfont *f) {
   gfxFont = (GFXfont *)f;
 }
 
+void Adafruit_GFX::clearChangedGlyph(char *previous, char *current, 
+  int16_t x, int16_t y, uint16_t color) {
+
+  int16_t  x1, y1;
+  uint16_t w, h;
+  uint8_t length = strlen(previous);
+  uint8_t glyphWidths[length];
+
+  getTextBounds(previous, x, y, &x1, &y1, &w, &h, glyphWidths);
+
+  uint8_t cursor_x = x1;
+  for(uint8_t i = 0; i < length; i++) {
+    if(previous[i] != current[i]) {
+      fillRect(cursor_x, y1, glyphWidths[i], h, color);
+    }
+    cursor_x += glyphWidths[i];
+  }
+}
+
 // Pass string and a cursor position, returns UL corner and W,H.
 void Adafruit_GFX::getTextBounds(char *str, int16_t x, int16_t y,
  int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h, uint8_t * glyphWidths) {
@@ -736,7 +755,7 @@ void Adafruit_GFX::getTextBounds(char *str, int16_t x, int16_t y,
             if(gy2 > maxy) maxy = gy2;
             x += xa * ts;
 
-            if(glyphWidths != NULL) *glyphWidths++ = xa * ts;
+            *glyphWidths++ = xa * ts;
           }
         } // Carriage return = do nothing
       } else { // Newline
@@ -765,7 +784,7 @@ void Adafruit_GFX::getTextBounds(char *str, int16_t x, int16_t y,
           } else { // No line wrap, just keep incrementing X
             lineWidth += textsize * 6; // Includes interchar x gap
           }
-          if(glyphWidths != NULL) *glyphWidths++ = textsize * 6;
+          *glyphWidths++ = textsize * 6;
         } // Carriage return = do nothing
       } else { // Newline
         x  = 0;            // Reset x to 0
@@ -778,6 +797,95 @@ void Adafruit_GFX::getTextBounds(char *str, int16_t x, int16_t y,
     if(lineWidth) y += textsize * 8; // Add height of last (or only) line
     *w = maxWidth - 1;               // Don't include last interchar x gap
     *h = y - *y1;
+  } // End classic vs custom font
+}
+
+// Pass string and a cursor position, returns UL corner and W,H.
+void Adafruit_GFX::getTextBounds(char *str, int16_t x, int16_t y,
+ int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h) {
+  uint8_t c; // Current character
+
+  *x1 = x;
+  *y1 = y;
+  *w  = *h = 0;
+
+  if(gfxFont) {
+
+    GFXglyph *glyph;
+    uint8_t   first = pgm_read_byte(&gfxFont->first),
+              last  = pgm_read_byte(&gfxFont->last),
+              gw, gh, xa;
+    int8_t    xo, yo;
+    int16_t   minx = _width, miny = _height, maxx = -1, maxy = -1,
+              gx1, gy1, gx2, gy2, ts = (int16_t)textsize,
+              ya = ts * (uint8_t)pgm_read_byte(&gfxFont->yAdvance);
+
+    while((c = *str++)) {
+      if(c != '\n') { // Not a newline
+        if(c != '\r') { // Not a carriage return, is normal char
+          if((c >= first) && (c <= last)) { // Char present in current font
+            c    -= first;
+            glyph = &(((GFXglyph *)pgm_read_pointer(&gfxFont->glyph))[c]);
+            gw    = pgm_read_byte(&glyph->width);
+            gh    = pgm_read_byte(&glyph->height);
+            xa    = pgm_read_byte(&glyph->xAdvance);
+            xo    = pgm_read_byte(&glyph->xOffset);
+            yo    = pgm_read_byte(&glyph->yOffset);
+            if(wrap && ((x + (((int16_t)xo + gw) * ts)) >= _width)) {
+              // Line wrap
+              x  = 0;  // Reset x to 0
+              y += ya; // Advance y by 1 line
+            }
+            gx1 = x   + xo * ts;
+            gy1 = y   + yo * ts;
+            gx2 = gx1 + gw * ts - 1;
+            gy2 = gy1 + gh * ts - 1;
+            if(gx1 < minx) minx = gx1;
+            if(gy1 < miny) miny = gy1;
+            if(gx2 > maxx) maxx = gx2;
+            if(gy2 > maxy) maxy = gy2;
+            x += xa * ts;
+          }
+        } // Carriage return = do nothing
+      } else { // Newline
+        x  = 0;  // Reset x
+        y += ya; // Advance y by 1 line
+      }
+    }
+    // End of string
+    *x1 = minx;
+    *y1 = miny;
+    if(maxx >= minx) *w  = maxx - minx + 1;
+    if(maxy >= miny) *h  = maxy - miny + 1;
+
+  } else { // Default font
+
+    uint16_t lineWidth = 0, maxWidth = 0; // Width of current, all lines
+
+    while((c = *str++)) {
+      if(c != '\n') { // Not a newline
+        if(c != '\r') { // Not a carriage return, is normal char
+          if(wrap && ((x + textsize * 6) >= _width)) {
+            x  = 0;            // Reset x to 0
+            y += textsize * 8; // Advance y by 1 line
+            if(lineWidth > maxWidth) maxWidth = lineWidth; // Save widest line
+            lineWidth  = textsize * 6; // First char on new line
+          } else { // No line wrap, just keep incrementing X
+            lineWidth += textsize * 6; // Includes interchar x gap
+          }
+        } // Carriage return = do nothing
+      } else { // Newline
+        x  = 0;            // Reset x to 0
+        y += textsize * 8; // Advance y by 1 line
+        if(lineWidth > maxWidth) maxWidth = lineWidth; // Save widest line
+        lineWidth = 0;     // Reset lineWidth for new line
+      }
+    }
+    // End of string
+    if(lineWidth) y += textsize * 8; // Add height of last (or only) line
+    *w = maxWidth - 1;               // Don't include last interchar x gap
+    *h = y - *y1;
+
   } // End classic vs custom font
 }
 

--- a/Adafruit_GFX.cpp
+++ b/Adafruit_GFX.cpp
@@ -385,7 +385,7 @@ void Adafruit_GFX::drawBitmap(int16_t x, int16_t y,
  const uint8_t *bitmap, int16_t w, int16_t h, uint16_t color) {
 
   int16_t i, j, byteWidth = (w + 7) / 8;
-  uint8_t byte;
+  uint8_t byte = 0;
 
   for(j=0; j<h; j++) {
     for(i=0; i<w; i++) {
@@ -562,12 +562,12 @@ void Adafruit_GFX::drawChar(int16_t x, int16_t y, unsigned char c,
 
     uint16_t bo = pgm_read_word(&glyph->bitmapOffset);
     uint8_t  w  = pgm_read_byte(&glyph->width),
-             h  = pgm_read_byte(&glyph->height),
-             xa = pgm_read_byte(&glyph->xAdvance);
+             h  = pgm_read_byte(&glyph->height);//,
+             //xa = pgm_read_byte(&glyph->xAdvance);
     int8_t   xo = pgm_read_byte(&glyph->xOffset),
              yo = pgm_read_byte(&glyph->yOffset);
-    uint8_t  xx, yy, bits, bit = 0;
-    int16_t  xo16, yo16;
+    uint8_t  xx = 0, yy = 0, bits = 0, bit = 0;
+    int16_t  xo16 = 0, yo16 = 0;
 
     if(size > 1) {
       xo16 = xo;
@@ -691,7 +691,7 @@ void Adafruit_GFX::setFont(const GFXfont *f) {
 
 // Pass string and a cursor position, returns UL corner and W,H.
 void Adafruit_GFX::getTextBounds(char *str, int16_t x, int16_t y,
- int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h) {
+ int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h, uint8_t * glyphWidths) {
   uint8_t c; // Current character
 
   *x1 = x;
@@ -716,6 +716,7 @@ void Adafruit_GFX::getTextBounds(char *str, int16_t x, int16_t y,
             c    -= first;
             glyph = &(((GFXglyph *)pgm_read_pointer(&gfxFont->glyph))[c]);
             gw    = pgm_read_byte(&glyph->width);
+            
             gh    = pgm_read_byte(&glyph->height);
             xa    = pgm_read_byte(&glyph->xAdvance);
             xo    = pgm_read_byte(&glyph->xOffset);
@@ -734,6 +735,8 @@ void Adafruit_GFX::getTextBounds(char *str, int16_t x, int16_t y,
             if(gx2 > maxx) maxx = gx2;
             if(gy2 > maxy) maxy = gy2;
             x += xa * ts;
+
+            if(glyphWidths != NULL) *glyphWidths++ = xa * ts;
           }
         } // Carriage return = do nothing
       } else { // Newline
@@ -762,6 +765,7 @@ void Adafruit_GFX::getTextBounds(char *str, int16_t x, int16_t y,
           } else { // No line wrap, just keep incrementing X
             lineWidth += textsize * 6; // Includes interchar x gap
           }
+          if(glyphWidths != NULL) *glyphWidths++ = textsize * 6;
         } // Carriage return = do nothing
       } else { // Newline
         x  = 0;            // Reset x to 0
@@ -772,10 +776,8 @@ void Adafruit_GFX::getTextBounds(char *str, int16_t x, int16_t y,
     }
     // End of string
     if(lineWidth) y += textsize * 8; // Add height of last (or only) line
-    if(lineWidth > maxWidth) maxWidth = lineWidth; // Is the last or only line the widest?
     *w = maxWidth - 1;               // Don't include last interchar x gap
     *h = y - *y1;
-
   } // End classic vs custom font
 }
 
@@ -862,7 +864,6 @@ void Adafruit_GFX::getTextBounds(const __FlashStringHelper *str,
     }
     // End of string
     if(lineWidth) y += textsize * 8; // Add height of last (or only) line
-    if(lineWidth > maxWidth) maxWidth = lineWidth; // Is the last or only line the widest?
     *w = maxWidth - 1;               // Don't include last interchar x gap
     *h = y - *y1;
 
@@ -878,9 +879,11 @@ int16_t Adafruit_GFX::height(void) const {
   return _height;
 }
 
+/*
 void Adafruit_GFX::invertDisplay(boolean i) {
   // Do nothing, must be subclassed if supported by hardware
 }
+*/
 
 /***************************************************************************/
 // code for the GFX button UI element
@@ -929,7 +932,7 @@ void Adafruit_GFX_Button::drawButton(boolean inverted) {
   _gfx->print(_label);
 }
 
-boolean Adafruit_GFX_Button::contains(int16_t x, int16_t y) {
+boolean Adafruit_GFX_Button::contains(uint16_t x, uint16_t y) {
   if ((x < (_x - _w/2)) || (x > (_x + _w/2))) return false;
   if ((y < (_y - _h/2)) || (y > (_y + _h/2))) return false;
   return true;

--- a/Adafruit_GFX.h
+++ b/Adafruit_GFX.h
@@ -1,159 +1,1183 @@
-#ifndef _ADAFRUIT_GFX_H
-#define _ADAFRUIT_GFX_H
+/*
+This is the core graphics library for all our displays, providing a common
+set of graphics primitives (points, lines, circles, etc.).  It needs to be
+paired with a hardware-specific library for each display device we carry
+(to handle the lower-level functions).
 
-#if ARDUINO >= 100
- #include "Arduino.h"
- #include "Print.h"
-#else
- #include "WProgram.h"
+Adafruit invests time and resources providing this open source code, please
+support Adafruit & open-source hardware by purchasing products from Adafruit!
+
+Copyright (c) 2013 Adafruit Industries.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+- Redistributions of source code must retain the above copyright notice,
+  this list of conditions and the following disclaimer.
+- Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifdef __AVR__
+ #include <avr/pgmspace.h>
+#elif defined(ESP8266)
+ #include <pgmspace.h>
+#endif
+#include "Adafruit_GFX.h"
+#include "glcdfont.c"
+
+// Many (but maybe not all) non-AVR board installs define macros
+// for compatibility with existing PROGMEM-reading AVR code.
+// Do our own checks and defines here for good measure...
+
+#ifndef pgm_read_byte
+ #define pgm_read_byte(addr) (*(const unsigned char *)(addr))
+#endif
+#ifndef pgm_read_word
+ #define pgm_read_word(addr) (*(const unsigned short *)(addr))
+#endif
+#ifndef pgm_read_dword
+ #define pgm_read_dword(addr) (*(const unsigned long *)(addr))
 #endif
 
-#include "gfxfont.h"
+// Pointers are a peculiar case...typically 16-bit on AVR boards,
+// 32 bits elsewhere.  Try to accommodate both...
 
-class Adafruit_GFX : public Print {
-
- public:
-
-  Adafruit_GFX(int16_t w, int16_t h); // Constructor
-
-  // This MUST be defined by the subclass:
-  virtual void drawPixel(int16_t x, int16_t y, uint16_t color) = 0;
-
-  // These MAY be overridden by the subclass to provide device-specific
-  // optimized code.  Otherwise 'generic' versions are used.
-  virtual void
-    drawLine(int16_t x0, int16_t y0, int16_t x1, int16_t y1, uint16_t color),
-    drawFastVLine(int16_t x, int16_t y, int16_t h, uint16_t color),
-    drawFastHLine(int16_t x, int16_t y, int16_t w, uint16_t color),
-    drawRect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t color),
-    fillRect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t color),
-    fillScreen(uint16_t color),
-    invertDisplay(boolean i);
-
-  // These exist only with Adafruit_GFX (no subclass overrides)
-  void
-    drawCircle(int16_t x0, int16_t y0, int16_t r, uint16_t color),
-    drawCircleHelper(int16_t x0, int16_t y0, int16_t r, uint8_t cornername,
-      uint16_t color),
-    fillCircle(int16_t x0, int16_t y0, int16_t r, uint16_t color),
-    fillCircleHelper(int16_t x0, int16_t y0, int16_t r, uint8_t cornername,
-      int16_t delta, uint16_t color),
-    drawTriangle(int16_t x0, int16_t y0, int16_t x1, int16_t y1,
-      int16_t x2, int16_t y2, uint16_t color),
-    fillTriangle(int16_t x0, int16_t y0, int16_t x1, int16_t y1,
-      int16_t x2, int16_t y2, uint16_t color),
-    drawRoundRect(int16_t x0, int16_t y0, int16_t w, int16_t h,
-      int16_t radius, uint16_t color),
-    fillRoundRect(int16_t x0, int16_t y0, int16_t w, int16_t h,
-      int16_t radius, uint16_t color),
-    drawBitmap(int16_t x, int16_t y, const uint8_t *bitmap,
-      int16_t w, int16_t h, uint16_t color),
-    drawBitmap(int16_t x, int16_t y, const uint8_t *bitmap,
-      int16_t w, int16_t h, uint16_t color, uint16_t bg),
-    drawBitmap(int16_t x, int16_t y, uint8_t *bitmap,
-      int16_t w, int16_t h, uint16_t color),
-    drawBitmap(int16_t x, int16_t y, uint8_t *bitmap,
-      int16_t w, int16_t h, uint16_t color, uint16_t bg),
-    drawXBitmap(int16_t x, int16_t y, const uint8_t *bitmap,
-      int16_t w, int16_t h, uint16_t color),
-    drawChar(int16_t x, int16_t y, unsigned char c, uint16_t color,
-      uint16_t bg, uint8_t size),
-    setCursor(int16_t x, int16_t y),
-    setTextColor(uint16_t c),
-    setTextColor(uint16_t c, uint16_t bg),
-    setTextSize(uint8_t s),
-    setTextWrap(boolean w),
-    setRotation(uint8_t r),
-    cp437(boolean x=true),
-    setFont(const GFXfont *f = NULL),
-    clearChangedGlyph(char *previous, char *current, 
-      int16_t x, int16_t y, uint16_t color),
-    getTextBounds(char *str, int16_t x, int16_t y, int16_t *x1, 
-      int16_t *y1, uint16_t *w, uint16_t *h, uint8_t * glyphWidths),
-    getTextBounds(char *string, int16_t x, int16_t y,
-      int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h),
-    getTextBounds(const __FlashStringHelper *s, int16_t x, int16_t y,
-      int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h);
-
-#if ARDUINO >= 100
-  virtual size_t write(uint8_t);
+#if !defined(__INT_MAX__) || (__INT_MAX__ > 0xFFFF)
+ #define pgm_read_pointer(addr) ((void *)pgm_read_dword(addr))
 #else
-  virtual void   write(uint8_t);
+ #define pgm_read_pointer(addr) ((void *)pgm_read_word(addr))
 #endif
 
-  int16_t height(void) const;
-  int16_t width(void) const;
+#ifndef min
+#define min(a,b) (((a) < (b)) ? (a) : (b))
+#endif
 
-  uint8_t getRotation(void) const;
+#ifndef _swap_int16_t
+#define _swap_int16_t(a, b) { int16_t t = a; a = b; b = t; }
+#endif
 
-  // get current cursor position (get rotation safe maximum values, using: width() for x, height() for y)
-  int16_t getCursorX(void) const;
-  int16_t getCursorY(void) const;
+Adafruit_GFX::Adafruit_GFX(int16_t w, int16_t h):
+  WIDTH(w), HEIGHT(h)
+{
+  _width    = WIDTH;
+  _height   = HEIGHT;
+  rotation  = 0;
+  cursor_y  = cursor_x    = 0;
+  textsize  = 1;
+  textcolor = textbgcolor = 0xFFFF;
+  wrap      = true;
+  _cp437    = false;
+  gfxFont   = NULL;
+}
 
- protected:
-  const int16_t
-    WIDTH, HEIGHT;   // This is the 'raw' display w/h - never changes
+// Draw a circle outline
+void Adafruit_GFX::drawCircle(int16_t x0, int16_t y0, int16_t r,
+ uint16_t color) {
+  int16_t f = 1 - r;
+  int16_t ddF_x = 1;
+  int16_t ddF_y = -2 * r;
+  int16_t x = 0;
+  int16_t y = r;
+
+  drawPixel(x0  , y0+r, color);
+  drawPixel(x0  , y0-r, color);
+  drawPixel(x0+r, y0  , color);
+  drawPixel(x0-r, y0  , color);
+
+  while (x<y) {
+    if (f >= 0) {
+      y--;
+      ddF_y += 2;
+      f += ddF_y;
+    }
+    x++;
+    ddF_x += 2;
+    f += ddF_x;
+
+    drawPixel(x0 + x, y0 + y, color);
+    drawPixel(x0 - x, y0 + y, color);
+    drawPixel(x0 + x, y0 - y, color);
+    drawPixel(x0 - x, y0 - y, color);
+    drawPixel(x0 + y, y0 + x, color);
+    drawPixel(x0 - y, y0 + x, color);
+    drawPixel(x0 + y, y0 - x, color);
+    drawPixel(x0 - y, y0 - x, color);
+  }
+}
+
+void Adafruit_GFX::drawCircleHelper( int16_t x0, int16_t y0,
+ int16_t r, uint8_t cornername, uint16_t color) {
+  int16_t f     = 1 - r;
+  int16_t ddF_x = 1;
+  int16_t ddF_y = -2 * r;
+  int16_t x     = 0;
+  int16_t y     = r;
+
+  while (x<y) {
+    if (f >= 0) {
+      y--;
+      ddF_y += 2;
+      f     += ddF_y;
+    }
+    x++;
+    ddF_x += 2;
+    f     += ddF_x;
+    if (cornername & 0x4) {
+      drawPixel(x0 + x, y0 + y, color);
+      drawPixel(x0 + y, y0 + x, color);
+    }
+    if (cornername & 0x2) {
+      drawPixel(x0 + x, y0 - y, color);
+      drawPixel(x0 + y, y0 - x, color);
+    }
+    if (cornername & 0x8) {
+      drawPixel(x0 - y, y0 + x, color);
+      drawPixel(x0 - x, y0 + y, color);
+    }
+    if (cornername & 0x1) {
+      drawPixel(x0 - y, y0 - x, color);
+      drawPixel(x0 - x, y0 - y, color);
+    }
+  }
+}
+
+void Adafruit_GFX::fillCircle(int16_t x0, int16_t y0, int16_t r,
+ uint16_t color) {
+  drawFastVLine(x0, y0-r, 2*r+1, color);
+  fillCircleHelper(x0, y0, r, 3, 0, color);
+}
+
+// Used to do circles and roundrects
+void Adafruit_GFX::fillCircleHelper(int16_t x0, int16_t y0, int16_t r,
+ uint8_t cornername, int16_t delta, uint16_t color) {
+
+  int16_t f     = 1 - r;
+  int16_t ddF_x = 1;
+  int16_t ddF_y = -2 * r;
+  int16_t x     = 0;
+  int16_t y     = r;
+
+  while (x<y) {
+    if (f >= 0) {
+      y--;
+      ddF_y += 2;
+      f     += ddF_y;
+    }
+    x++;
+    ddF_x += 2;
+    f     += ddF_x;
+
+    if (cornername & 0x1) {
+      drawFastVLine(x0+x, y0-y, 2*y+1+delta, color);
+      drawFastVLine(x0+y, y0-x, 2*x+1+delta, color);
+    }
+    if (cornername & 0x2) {
+      drawFastVLine(x0-x, y0-y, 2*y+1+delta, color);
+      drawFastVLine(x0-y, y0-x, 2*x+1+delta, color);
+    }
+  }
+}
+
+// Bresenham's algorithm - thx wikpedia
+void Adafruit_GFX::drawLine(int16_t x0, int16_t y0, int16_t x1, int16_t y1,
+ uint16_t color) {
+  int16_t steep = abs(y1 - y0) > abs(x1 - x0);
+  if (steep) {
+    _swap_int16_t(x0, y0);
+    _swap_int16_t(x1, y1);
+  }
+
+  if (x0 > x1) {
+    _swap_int16_t(x0, x1);
+    _swap_int16_t(y0, y1);
+  }
+
+  int16_t dx, dy;
+  dx = x1 - x0;
+  dy = abs(y1 - y0);
+
+  int16_t err = dx / 2;
+  int16_t ystep;
+
+  if (y0 < y1) {
+    ystep = 1;
+  } else {
+    ystep = -1;
+  }
+
+  for (; x0<=x1; x0++) {
+    if (steep) {
+      drawPixel(y0, x0, color);
+    } else {
+      drawPixel(x0, y0, color);
+    }
+    err -= dy;
+    if (err < 0) {
+      y0 += ystep;
+      err += dx;
+    }
+  }
+}
+
+// Draw a rectangle
+void Adafruit_GFX::drawRect(int16_t x, int16_t y, int16_t w, int16_t h,
+ uint16_t color) {
+  drawFastHLine(x, y, w, color);
+  drawFastHLine(x, y+h-1, w, color);
+  drawFastVLine(x, y, h, color);
+  drawFastVLine(x+w-1, y, h, color);
+}
+
+void Adafruit_GFX::drawFastVLine(int16_t x, int16_t y,
+ int16_t h, uint16_t color) {
+  // Update in subclasses if desired!
+  drawLine(x, y, x, y+h-1, color);
+}
+
+void Adafruit_GFX::drawFastHLine(int16_t x, int16_t y,
+ int16_t w, uint16_t color) {
+  // Update in subclasses if desired!
+  drawLine(x, y, x+w-1, y, color);
+}
+
+void Adafruit_GFX::fillRect(int16_t x, int16_t y, int16_t w, int16_t h,
+ uint16_t color) {
+  // Update in subclasses if desired!
+  for (int16_t i=x; i<x+w; i++) {
+    drawFastVLine(i, y, h, color);
+  }
+}
+
+void Adafruit_GFX::fillScreen(uint16_t color) {
+  fillRect(0, 0, _width, _height, color);
+}
+
+// Draw a rounded rectangle
+void Adafruit_GFX::drawRoundRect(int16_t x, int16_t y, int16_t w,
+ int16_t h, int16_t r, uint16_t color) {
+  // smarter version
+  drawFastHLine(x+r  , y    , w-2*r, color); // Top
+  drawFastHLine(x+r  , y+h-1, w-2*r, color); // Bottom
+  drawFastVLine(x    , y+r  , h-2*r, color); // Left
+  drawFastVLine(x+w-1, y+r  , h-2*r, color); // Right
+  // draw four corners
+  drawCircleHelper(x+r    , y+r    , r, 1, color);
+  drawCircleHelper(x+w-r-1, y+r    , r, 2, color);
+  drawCircleHelper(x+w-r-1, y+h-r-1, r, 4, color);
+  drawCircleHelper(x+r    , y+h-r-1, r, 8, color);
+}
+
+// Fill a rounded rectangle
+void Adafruit_GFX::fillRoundRect(int16_t x, int16_t y, int16_t w,
+ int16_t h, int16_t r, uint16_t color) {
+  // smarter version
+  fillRect(x+r, y, w-2*r, h, color);
+
+  // draw four corners
+  fillCircleHelper(x+w-r-1, y+r, r, 1, h-2*r-1, color);
+  fillCircleHelper(x+r    , y+r, r, 2, h-2*r-1, color);
+}
+
+// Draw a triangle
+void Adafruit_GFX::drawTriangle(int16_t x0, int16_t y0,
+ int16_t x1, int16_t y1, int16_t x2, int16_t y2, uint16_t color) {
+  drawLine(x0, y0, x1, y1, color);
+  drawLine(x1, y1, x2, y2, color);
+  drawLine(x2, y2, x0, y0, color);
+}
+
+// Fill a triangle
+void Adafruit_GFX::fillTriangle(int16_t x0, int16_t y0,
+ int16_t x1, int16_t y1, int16_t x2, int16_t y2, uint16_t color) {
+
+  int16_t a, b, y, last;
+
+  // Sort coordinates by Y order (y2 >= y1 >= y0)
+  if (y0 > y1) {
+    _swap_int16_t(y0, y1); _swap_int16_t(x0, x1);
+  }
+  if (y1 > y2) {
+    _swap_int16_t(y2, y1); _swap_int16_t(x2, x1);
+  }
+  if (y0 > y1) {
+    _swap_int16_t(y0, y1); _swap_int16_t(x0, x1);
+  }
+
+  if(y0 == y2) { // Handle awkward all-on-same-line case as its own thing
+    a = b = x0;
+    if(x1 < a)      a = x1;
+    else if(x1 > b) b = x1;
+    if(x2 < a)      a = x2;
+    else if(x2 > b) b = x2;
+    drawFastHLine(a, y0, b-a+1, color);
+    return;
+  }
+
   int16_t
-    _width, _height, // Display w/h as modified by current rotation
-    cursor_x, cursor_y;
-  uint16_t
-    textcolor, textbgcolor;
-  uint8_t
-    textsize,
-    rotation;
-  boolean
-    wrap,   // If set, 'wrap' text at right edge of display
-    _cp437; // If set, use correct CP437 charset (default is off)
-  GFXfont
-    *gfxFont;
-};
+    dx01 = x1 - x0,
+    dy01 = y1 - y0,
+    dx02 = x2 - x0,
+    dy02 = y2 - y0,
+    dx12 = x2 - x1,
+    dy12 = y2 - y1;
+  int32_t
+    sa   = 0,
+    sb   = 0;
 
-class Adafruit_GFX_Button {
+  // For upper part of triangle, find scanline crossings for segments
+  // 0-1 and 0-2.  If y1=y2 (flat-bottomed triangle), the scanline y1
+  // is included here (and second loop will be skipped, avoiding a /0
+  // error there), otherwise scanline y1 is skipped here and handled
+  // in the second loop...which also avoids a /0 error here if y0=y1
+  // (flat-topped triangle).
+  if(y1 == y2) last = y1;   // Include y1 scanline
+  else         last = y1-1; // Skip it
 
- public:
-  Adafruit_GFX_Button(void);
-  void initButton(Adafruit_GFX *gfx, int16_t x, int16_t y,
-   uint8_t w, uint8_t h, uint16_t outline, uint16_t fill,
-   uint16_t textcolor, char *label, uint8_t textsize);
-  void drawButton(boolean inverted = false);
-  boolean contains(uint16_t x, uint16_t y);
+  for(y=y0; y<=last; y++) {
+    a   = x0 + sa / dy01;
+    b   = x0 + sb / dy02;
+    sa += dx01;
+    sb += dx02;
+    /* longhand:
+    a = x0 + (x1 - x0) * (y - y0) / (y1 - y0);
+    b = x0 + (x2 - x0) * (y - y0) / (y2 - y0);
+    */
+    if(a > b) _swap_int16_t(a,b);
+    drawFastHLine(a, y, b-a+1, color);
+  }
 
-  void press(boolean p);
-  boolean isPressed();
-  boolean justPressed();
-  boolean justReleased();
+  // For lower part of triangle, find scanline crossings for segments
+  // 0-2 and 1-2.  This loop is skipped if y1=y2.
+  sa = dx12 * (y - y1);
+  sb = dx02 * (y - y0);
+  for(; y<=y2; y++) {
+    a   = x1 + sa / dy12;
+    b   = x0 + sb / dy02;
+    sa += dx12;
+    sb += dx02;
+    /* longhand:
+    a = x1 + (x2 - x1) * (y - y1) / (y2 - y1);
+    b = x0 + (x2 - x0) * (y - y0) / (y2 - y0);
+    */
+    if(a > b) _swap_int16_t(a,b);
+    drawFastHLine(a, y, b-a+1, color);
+  }
+}
 
- private:
-  Adafruit_GFX *_gfx;
-  int16_t _x, _y;
-  uint16_t _w, _h;
-  uint8_t _textsize;
-  uint16_t _outlinecolor, _fillcolor, _textcolor;
-  char _label[10];
+// Draw a 1-bit image (bitmap) at the specified (x,y) position from the
+// provided bitmap buffer (must be PROGMEM memory) using the specified
+// foreground color (unset bits are transparent).
+void Adafruit_GFX::drawBitmap(int16_t x, int16_t y,
+ const uint8_t *bitmap, int16_t w, int16_t h, uint16_t color) {
 
-  boolean currstate, laststate;
-};
+  int16_t i, j, byteWidth = (w + 7) / 8;
+  uint8_t byte = 0;
 
-class GFXcanvas1 : public Adafruit_GFX {
+  for(j=0; j<h; j++) {
+    for(i=0; i<w; i++) {
+      if(i & 7) byte <<= 1;
+      else      byte   = pgm_read_byte(bitmap + j * byteWidth + i / 8);
+      if(byte & 0x80) drawPixel(x+i, y+j, color);
+    }
+  }
+}
 
- public:
-  GFXcanvas1(uint16_t w, uint16_t h);
-  ~GFXcanvas1(void);
-  void     drawPixel(int16_t x, int16_t y, uint16_t color),
-           fillScreen(uint16_t color);
-  uint8_t *getBuffer(void);
- private:
-  uint8_t *buffer;
-};
+// Draw a 1-bit image (bitmap) at the specified (x,y) position from the
+// provided bitmap buffer (must be PROGMEM memory) using the specified
+// foreground (for set bits) and background (for clear bits) colors.
+void Adafruit_GFX::drawBitmap(int16_t x, int16_t y,
+ const uint8_t *bitmap, int16_t w, int16_t h, uint16_t color, uint16_t bg) {
 
-class GFXcanvas16 : public Adafruit_GFX {
-  GFXcanvas16(uint16_t w, uint16_t h);
-  ~GFXcanvas16(void);
-  void      drawPixel(int16_t x, int16_t y, uint16_t color),
-            fillScreen(uint16_t color);
-  uint16_t *getBuffer(void);
- private:
-  uint16_t *buffer;
-};
+  int16_t i, j, byteWidth = (w + 7) / 8;
+  uint8_t byte;
 
-#endif // _ADAFRUIT_GFX_H
+  for(j=0; j<h; j++) {
+    for(i=0; i<w; i++ ) {
+      if(i & 7) byte <<= 1;
+      else      byte   = pgm_read_byte(bitmap + j * byteWidth + i / 8);
+      if(byte & 0x80) drawPixel(x+i, y+j, color);
+      else            drawPixel(x+i, y+j, bg);
+    }
+  }
+}
+
+// drawBitmap() variant for RAM-resident (not PROGMEM) bitmaps.
+void Adafruit_GFX::drawBitmap(int16_t x, int16_t y,
+ uint8_t *bitmap, int16_t w, int16_t h, uint16_t color) {
+
+  int16_t i, j, byteWidth = (w + 7) / 8;
+  uint8_t byte;
+
+  for(j=0; j<h; j++) {
+    for(i=0; i<w; i++ ) {
+      if(i & 7) byte <<= 1;
+      else      byte   = bitmap[j * byteWidth + i / 8];
+      if(byte & 0x80) drawPixel(x+i, y+j, color);
+    }
+  }
+}
+
+// drawBitmap() variant w/background for RAM-resident (not PROGMEM) bitmaps.
+void Adafruit_GFX::drawBitmap(int16_t x, int16_t y,
+ uint8_t *bitmap, int16_t w, int16_t h, uint16_t color, uint16_t bg) {
+
+  int16_t i, j, byteWidth = (w + 7) / 8;
+  uint8_t byte;
+
+  for(j=0; j<h; j++) {
+    for(i=0; i<w; i++ ) {
+      if(i & 7) byte <<= 1;
+      else      byte   = bitmap[j * byteWidth + i / 8];
+      if(byte & 0x80) drawPixel(x+i, y+j, color);
+      else            drawPixel(x+i, y+j, bg);
+    }
+  }
+}
+
+//Draw XBitMap Files (*.xbm), exported from GIMP,
+//Usage: Export from GIMP to *.xbm, rename *.xbm to *.c and open in editor.
+//C Array can be directly used with this function
+void Adafruit_GFX::drawXBitmap(int16_t x, int16_t y,
+ const uint8_t *bitmap, int16_t w, int16_t h, uint16_t color) {
+
+  int16_t i, j, byteWidth = (w + 7) / 8;
+  uint8_t byte;
+
+  for(j=0; j<h; j++) {
+    for(i=0; i<w; i++ ) {
+      if(i & 7) byte >>= 1;
+      else      byte   = pgm_read_byte(bitmap + j * byteWidth + i / 8);
+      if(byte & 0x01) drawPixel(x+i, y+j, color);
+    }
+  }
+}
+
+#if ARDUINO >= 100
+size_t Adafruit_GFX::write(uint8_t c) {
+#else
+void Adafruit_GFX::write(uint8_t c) {
+#endif
+
+  if(!gfxFont) { // 'Classic' built-in font
+
+    if(c == '\n') {
+      cursor_y += textsize*8;
+      cursor_x  = 0;
+    } else if(c == '\r') {
+      // skip em
+    } else {
+      if(wrap && ((cursor_x + textsize * 6) >= _width)) { // Heading off edge?
+        cursor_x  = 0;            // Reset x to zero
+        cursor_y += textsize * 8; // Advance y one line
+      }
+      drawChar(cursor_x, cursor_y, c, textcolor, textbgcolor, textsize);
+      cursor_x += textsize * 6;
+    }
+
+  } else { // Custom font
+
+    if(c == '\n') {
+      cursor_x  = 0;
+      cursor_y += (int16_t)textsize *
+                  (uint8_t)pgm_read_byte(&gfxFont->yAdvance);
+    } else if(c != '\r') {
+      uint8_t first = pgm_read_byte(&gfxFont->first);
+      if((c >= first) && (c <= (uint8_t)pgm_read_byte(&gfxFont->last))) {
+        uint8_t   c2    = c - pgm_read_byte(&gfxFont->first);
+        GFXglyph *glyph = &(((GFXglyph *)pgm_read_pointer(&gfxFont->glyph))[c2]);
+        uint8_t   w     = pgm_read_byte(&glyph->width),
+                  h     = pgm_read_byte(&glyph->height);
+        if((w > 0) && (h > 0)) { // Is there an associated bitmap?
+          int16_t xo = (int8_t)pgm_read_byte(&glyph->xOffset); // sic
+          if(wrap && ((cursor_x + textsize * (xo + w)) >= _width)) {
+            // Drawing character would go off right edge; wrap to new line
+            cursor_x  = 0;
+            cursor_y += (int16_t)textsize *
+                        (uint8_t)pgm_read_byte(&gfxFont->yAdvance);
+          }
+          drawChar(cursor_x, cursor_y, c, textcolor, textbgcolor, textsize);
+        }
+        cursor_x += pgm_read_byte(&glyph->xAdvance) * (int16_t)textsize;
+      }
+    }
+
+  }
+#if ARDUINO >= 100
+  return 1;
+#endif
+}
+
+// Draw a character
+void Adafruit_GFX::drawChar(int16_t x, int16_t y, unsigned char c,
+ uint16_t color, uint16_t bg, uint8_t size) {
+
+  if(!gfxFont) { // 'Classic' built-in font
+
+    if((x >= _width)            || // Clip right
+       (y >= _height)           || // Clip bottom
+       ((x + 6 * size - 1) < 0) || // Clip left
+       ((y + 8 * size - 1) < 0))   // Clip top
+      return;
+
+    if(!_cp437 && (c >= 176)) c++; // Handle 'classic' charset behavior
+
+    for(int8_t i=0; i<6; i++ ) {
+      uint8_t line;
+      if(i < 5) line = pgm_read_byte(font+(c*5)+i);
+      else      line = 0x0;
+      for(int8_t j=0; j<8; j++, line >>= 1) {
+        if(line & 0x1) {
+          if(size == 1) drawPixel(x+i, y+j, color);
+          else          fillRect(x+(i*size), y+(j*size), size, size, color);
+        } else if(bg != color) {
+          if(size == 1) drawPixel(x+i, y+j, bg);
+          else          fillRect(x+i*size, y+j*size, size, size, bg);
+        }
+      }
+    }
+
+  } else { // Custom font
+
+    // Character is assumed previously filtered by write() to eliminate
+    // newlines, returns, non-printable characters, etc.  Calling drawChar()
+    // directly with 'bad' characters of font may cause mayhem!
+
+    c -= pgm_read_byte(&gfxFont->first);
+    GFXglyph *glyph  = &(((GFXglyph *)pgm_read_pointer(&gfxFont->glyph))[c]);
+    uint8_t  *bitmap = (uint8_t *)pgm_read_pointer(&gfxFont->bitmap);
+
+    uint16_t bo = pgm_read_word(&glyph->bitmapOffset);
+    uint8_t  w  = pgm_read_byte(&glyph->width),
+             h  = pgm_read_byte(&glyph->height);//,
+             //xa = pgm_read_byte(&glyph->xAdvance);
+    int8_t   xo = pgm_read_byte(&glyph->xOffset),
+             yo = pgm_read_byte(&glyph->yOffset);
+    uint8_t  xx = 0, yy = 0, bits = 0, bit = 0;
+    int16_t  xo16 = 0, yo16 = 0;
+
+    if(size > 1) {
+      xo16 = xo;
+      yo16 = yo;
+    }
+
+    // Todo: Add character clipping here
+
+    // NOTE: THERE IS NO 'BACKGROUND' COLOR OPTION ON CUSTOM FONTS.
+    // THIS IS ON PURPOSE AND BY DESIGN.  The background color feature
+    // has typically been used with the 'classic' font to overwrite old
+    // screen contents with new data.  This ONLY works because the
+    // characters are a uniform size; it's not a sensible thing to do with
+    // proportionally-spaced fonts with glyphs of varying sizes (and that
+    // may overlap).  To replace previously-drawn text when using a custom
+    // font, use the getTextBounds() function to determine the smallest
+    // rectangle encompassing a string, erase the area with fillRect(),
+    // then draw new text.  This WILL infortunately 'blink' the text, but
+    // is unavoidable.  Drawing 'background' pixels will NOT fix this,
+    // only creates a new set of problems.  Have an idea to work around
+    // this (a canvas object type for MCUs that can afford the RAM and
+    // displays supporting setAddrWindow() and pushColors()), but haven't
+    // implemented this yet.
+
+    for(yy=0; yy<h; yy++) {
+      for(xx=0; xx<w; xx++) {
+        if(!(bit++ & 7)) {
+          bits = pgm_read_byte(&bitmap[bo++]);
+        }
+        if(bits & 0x80) {
+          if(size == 1) {
+            drawPixel(x+xo+xx, y+yo+yy, color);
+          } else {
+            fillRect(x+(xo16+xx)*size, y+(yo16+yy)*size, size, size, color);
+          }
+        }
+        bits <<= 1;
+      }
+    }
+
+  } // End classic vs custom font
+}
+
+void Adafruit_GFX::setCursor(int16_t x, int16_t y) {
+  cursor_x = x;
+  cursor_y = y;
+}
+
+int16_t Adafruit_GFX::getCursorX(void) const {
+  return cursor_x;
+}
+
+int16_t Adafruit_GFX::getCursorY(void) const {
+  return cursor_y;
+}
+
+void Adafruit_GFX::setTextSize(uint8_t s) {
+  textsize = (s > 0) ? s : 1;
+}
+
+void Adafruit_GFX::setTextColor(uint16_t c) {
+  // For 'transparent' background, we'll set the bg
+  // to the same as fg instead of using a flag
+  textcolor = textbgcolor = c;
+}
+
+void Adafruit_GFX::setTextColor(uint16_t c, uint16_t b) {
+  textcolor   = c;
+  textbgcolor = b;
+}
+
+void Adafruit_GFX::setTextWrap(boolean w) {
+  wrap = w;
+}
+
+uint8_t Adafruit_GFX::getRotation(void) const {
+  return rotation;
+}
+
+void Adafruit_GFX::setRotation(uint8_t x) {
+  rotation = (x & 3);
+  switch(rotation) {
+   case 0:
+   case 2:
+    _width  = WIDTH;
+    _height = HEIGHT;
+    break;
+   case 1:
+   case 3:
+    _width  = HEIGHT;
+    _height = WIDTH;
+    break;
+  }
+}
+
+// Enable (or disable) Code Page 437-compatible charset.
+// There was an error in glcdfont.c for the longest time -- one character
+// (#176, the 'light shade' block) was missing -- this threw off the index
+// of every character that followed it.  But a TON of code has been written
+// with the erroneous character indices.  By default, the library uses the
+// original 'wrong' behavior and old sketches will still work.  Pass 'true'
+// to this function to use correct CP437 character values in your code.
+void Adafruit_GFX::cp437(boolean x) {
+  _cp437 = x;
+}
+
+void Adafruit_GFX::setFont(const GFXfont *f) {
+  if(f) {          // Font struct pointer passed in?
+    if(!gfxFont) { // And no current font struct?
+      // Switching from classic to new font behavior.
+      // Move cursor pos down 6 pixels so it's on baseline.
+      cursor_y += 6;
+    }
+  } else if(gfxFont) { // NULL passed.  Current font struct defined?
+    // Switching from new to classic font behavior.
+    // Move cursor pos up 6 pixels so it's at top-left of char.
+    cursor_y -= 6;
+  }
+  gfxFont = (GFXfont *)f;
+}
+// Takes two char array, checks wich glyph has changed within
+// the current one, and clears the background of just that glyph
+void Adafruit_GFX::clearChangedGlyph(char *previous, char *current, 
+  int16_t x, int16_t y, uint16_t color) {
+
+  int16_t  x1, y1;
+  uint16_t w, h;
+  uint8_t length = strlen(previous);
+  uint8_t glyphWidths[length];
+
+  getTextBounds(previous, x, y, &x1, &y1, &w, &h, glyphWidths);
+
+  uint8_t cursor_x = x1;
+  for(uint8_t i = 0; i < length; i++) {
+    if(previous[i] != current[i]) {
+      fillRect(cursor_x, y1, glyphWidths[i], h, color);
+    }
+    cursor_x += glyphWidths[i];
+  }
+}
+
+// Pass string and a cursor position, returns UL corner and W,H.
+void Adafruit_GFX::getTextBounds(char *str, int16_t x, int16_t y,
+ int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h, uint8_t * glyphWidths) {
+  uint8_t c; // Current character
+
+  *x1 = x;
+  *y1 = y;
+  *w  = *h = 0;
+
+  if(gfxFont) {
+
+    GFXglyph *glyph;
+    uint8_t   first = pgm_read_byte(&gfxFont->first),
+              last  = pgm_read_byte(&gfxFont->last),
+              gw, gh, xa;
+    int8_t    xo, yo;
+    int16_t   minx = _width, miny = _height, maxx = -1, maxy = -1,
+              gx1, gy1, gx2, gy2, ts = (int16_t)textsize,
+              ya = ts * (uint8_t)pgm_read_byte(&gfxFont->yAdvance);
+
+    while((c = *str++)) {
+      if(c != '\n') { // Not a newline
+        if(c != '\r') { // Not a carriage return, is normal char
+          if((c >= first) && (c <= last)) { // Char present in current font
+            c    -= first;
+            glyph = &(((GFXglyph *)pgm_read_pointer(&gfxFont->glyph))[c]);
+            gw    = pgm_read_byte(&glyph->width);
+            
+            gh    = pgm_read_byte(&glyph->height);
+            xa    = pgm_read_byte(&glyph->xAdvance);
+            xo    = pgm_read_byte(&glyph->xOffset);
+            yo    = pgm_read_byte(&glyph->yOffset);
+            if(wrap && ((x + (((int16_t)xo + gw) * ts)) >= _width)) {
+              // Line wrap
+              x  = 0;  // Reset x to 0
+              y += ya; // Advance y by 1 line
+            }
+            gx1 = x   + xo * ts;
+            gy1 = y   + yo * ts;
+            gx2 = gx1 + gw * ts - 1;
+            gy2 = gy1 + gh * ts - 1;
+            if(gx1 < minx) minx = gx1;
+            if(gy1 < miny) miny = gy1;
+            if(gx2 > maxx) maxx = gx2;
+            if(gy2 > maxy) maxy = gy2;
+            x += xa * ts;
+
+            *glyphWidths++ = xa * ts;
+          }
+        } // Carriage return = do nothing
+      } else { // Newline
+        x  = 0;  // Reset x
+        y += ya; // Advance y by 1 line
+      }
+    }
+    // End of string
+    *x1 = minx;
+    *y1 = miny;
+    if(maxx >= minx) *w  = maxx - minx + 1;
+    if(maxy >= miny) *h  = maxy - miny + 1;
+
+  } else { // Default font
+
+    uint16_t lineWidth = 0, maxWidth = 0; // Width of current, all lines
+
+    while((c = *str++)) {
+      if(c != '\n') { // Not a newline
+        if(c != '\r') { // Not a carriage return, is normal char
+          if(wrap && ((x + textsize * 6) >= _width)) {
+            x  = 0;            // Reset x to 0
+            y += textsize * 8; // Advance y by 1 line
+            if(lineWidth > maxWidth) maxWidth = lineWidth; // Save widest line
+            lineWidth  = textsize * 6; // First char on new line
+          } else { // No line wrap, just keep incrementing X
+            lineWidth += textsize * 6; // Includes interchar x gap
+          }
+          *glyphWidths++ = textsize * 6;
+        } // Carriage return = do nothing
+      } else { // Newline
+        x  = 0;            // Reset x to 0
+        y += textsize * 8; // Advance y by 1 line
+        if(lineWidth > maxWidth) maxWidth = lineWidth; // Save widest line
+        lineWidth = 0;     // Reset lineWidth for new line
+      }
+    }
+    // End of string
+    if(lineWidth) y += textsize * 8; // Add height of last (or only) line
+    *w = maxWidth - 1;               // Don't include last interchar x gap
+    *h = y - *y1;
+  } // End classic vs custom font
+}
+
+// Pass string and a cursor position, returns UL corner and W,H.
+void Adafruit_GFX::getTextBounds(char *str, int16_t x, int16_t y,
+ int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h) {
+  uint8_t c; // Current character
+
+  *x1 = x;
+  *y1 = y;
+  *w  = *h = 0;
+
+  if(gfxFont) {
+
+    GFXglyph *glyph;
+    uint8_t   first = pgm_read_byte(&gfxFont->first),
+              last  = pgm_read_byte(&gfxFont->last),
+              gw, gh, xa;
+    int8_t    xo, yo;
+    int16_t   minx = _width, miny = _height, maxx = -1, maxy = -1,
+              gx1, gy1, gx2, gy2, ts = (int16_t)textsize,
+              ya = ts * (uint8_t)pgm_read_byte(&gfxFont->yAdvance);
+
+    while((c = *str++)) {
+      if(c != '\n') { // Not a newline
+        if(c != '\r') { // Not a carriage return, is normal char
+          if((c >= first) && (c <= last)) { // Char present in current font
+            c    -= first;
+            glyph = &(((GFXglyph *)pgm_read_pointer(&gfxFont->glyph))[c]);
+            gw    = pgm_read_byte(&glyph->width);
+            gh    = pgm_read_byte(&glyph->height);
+            xa    = pgm_read_byte(&glyph->xAdvance);
+            xo    = pgm_read_byte(&glyph->xOffset);
+            yo    = pgm_read_byte(&glyph->yOffset);
+            if(wrap && ((x + (((int16_t)xo + gw) * ts)) >= _width)) {
+              // Line wrap
+              x  = 0;  // Reset x to 0
+              y += ya; // Advance y by 1 line
+            }
+            gx1 = x   + xo * ts;
+            gy1 = y   + yo * ts;
+            gx2 = gx1 + gw * ts - 1;
+            gy2 = gy1 + gh * ts - 1;
+            if(gx1 < minx) minx = gx1;
+            if(gy1 < miny) miny = gy1;
+            if(gx2 > maxx) maxx = gx2;
+            if(gy2 > maxy) maxy = gy2;
+            x += xa * ts;
+          }
+        } // Carriage return = do nothing
+      } else { // Newline
+        x  = 0;  // Reset x
+        y += ya; // Advance y by 1 line
+      }
+    }
+    // End of string
+    *x1 = minx;
+    *y1 = miny;
+    if(maxx >= minx) *w  = maxx - minx + 1;
+    if(maxy >= miny) *h  = maxy - miny + 1;
+
+  } else { // Default font
+
+    uint16_t lineWidth = 0, maxWidth = 0; // Width of current, all lines
+
+    while((c = *str++)) {
+      if(c != '\n') { // Not a newline
+        if(c != '\r') { // Not a carriage return, is normal char
+          if(wrap && ((x + textsize * 6) >= _width)) {
+            x  = 0;            // Reset x to 0
+            y += textsize * 8; // Advance y by 1 line
+            if(lineWidth > maxWidth) maxWidth = lineWidth; // Save widest line
+            lineWidth  = textsize * 6; // First char on new line
+          } else { // No line wrap, just keep incrementing X
+            lineWidth += textsize * 6; // Includes interchar x gap
+          }
+        } // Carriage return = do nothing
+      } else { // Newline
+        x  = 0;            // Reset x to 0
+        y += textsize * 8; // Advance y by 1 line
+        if(lineWidth > maxWidth) maxWidth = lineWidth; // Save widest line
+        lineWidth = 0;     // Reset lineWidth for new line
+      }
+    }
+    // End of string
+    if(lineWidth) y += textsize * 8; // Add height of last (or only) line
+    *w = maxWidth - 1;               // Don't include last interchar x gap
+    *h = y - *y1;
+
+  } // End classic vs custom font
+}
+
+// Same as above, but for PROGMEM strings
+void Adafruit_GFX::getTextBounds(const __FlashStringHelper *str,
+ int16_t x, int16_t y, int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h) {
+  uint8_t *s = (uint8_t *)str, c;
+
+  *x1 = x;
+  *y1 = y;
+  *w  = *h = 0;
+
+  if(gfxFont) {
+
+    GFXglyph *glyph;
+    uint8_t   first = pgm_read_byte(&gfxFont->first),
+              last  = pgm_read_byte(&gfxFont->last),
+              gw, gh, xa;
+    int8_t    xo, yo;
+    int16_t   minx = _width, miny = _height, maxx = -1, maxy = -1,
+              gx1, gy1, gx2, gy2, ts = (int16_t)textsize,
+              ya = ts * (uint8_t)pgm_read_byte(&gfxFont->yAdvance);
+
+    while((c = pgm_read_byte(s++))) {
+      if(c != '\n') { // Not a newline
+        if(c != '\r') { // Not a carriage return, is normal char
+          if((c >= first) && (c <= last)) { // Char present in current font
+            c    -= first;
+            glyph = &(((GFXglyph *)pgm_read_pointer(&gfxFont->glyph))[c]);
+            gw    = pgm_read_byte(&glyph->width);
+            gh    = pgm_read_byte(&glyph->height);
+            xa    = pgm_read_byte(&glyph->xAdvance);
+            xo    = pgm_read_byte(&glyph->xOffset);
+            yo    = pgm_read_byte(&glyph->yOffset);
+            if(wrap && ((x + (((int16_t)xo + gw) * ts)) >= _width)) {
+              // Line wrap
+              x  = 0;  // Reset x to 0
+              y += ya; // Advance y by 1 line
+            }
+            gx1 = x   + xo * ts;
+            gy1 = y   + yo * ts;
+            gx2 = gx1 + gw * ts - 1;
+            gy2 = gy1 + gh * ts - 1;
+            if(gx1 < minx) minx = gx1;
+            if(gy1 < miny) miny = gy1;
+            if(gx2 > maxx) maxx = gx2;
+            if(gy2 > maxy) maxy = gy2;
+            x += xa * ts;
+          }
+        } // Carriage return = do nothing
+      } else { // Newline
+        x  = 0;  // Reset x
+        y += ya; // Advance y by 1 line
+      }
+    }
+    // End of string
+    *x1 = minx;
+    *y1 = miny;
+    if(maxx >= minx) *w  = maxx - minx + 1;
+    if(maxy >= miny) *h  = maxy - miny + 1;
+
+  } else { // Default font
+
+    uint16_t lineWidth = 0, maxWidth = 0; // Width of current, all lines
+
+    while((c = pgm_read_byte(s++))) {
+      if(c != '\n') { // Not a newline
+        if(c != '\r') { // Not a carriage return, is normal char
+          if(wrap && ((x + textsize * 6) >= _width)) {
+            x  = 0;            // Reset x to 0
+            y += textsize * 8; // Advance y by 1 line
+            if(lineWidth > maxWidth) maxWidth = lineWidth; // Save widest line
+            lineWidth  = textsize * 6; // First char on new line
+          } else { // No line wrap, just keep incrementing X
+            lineWidth += textsize * 6; // Includes interchar x gap
+          }
+        } // Carriage return = do nothing
+      } else { // Newline
+        x  = 0;            // Reset x to 0
+        y += textsize * 8; // Advance y by 1 line
+        if(lineWidth > maxWidth) maxWidth = lineWidth; // Save widest line
+        lineWidth = 0;     // Reset lineWidth for new line
+      }
+    }
+    // End of string
+    if(lineWidth) y += textsize * 8; // Add height of last (or only) line
+    *w = maxWidth - 1;               // Don't include last interchar x gap
+    *h = y - *y1;
+
+  } // End classic vs custom font
+}
+
+// Return the size of the display (per current rotation)
+int16_t Adafruit_GFX::width(void) const {
+  return _width;
+}
+
+int16_t Adafruit_GFX::height(void) const {
+  return _height;
+}
+
+/*
+void Adafruit_GFX::invertDisplay(boolean i) {
+  // Do nothing, must be subclassed if supported by hardware
+}
+*/
+
+/***************************************************************************/
+// code for the GFX button UI element
+
+Adafruit_GFX_Button::Adafruit_GFX_Button(void) {
+  _gfx = 0;
+}
+
+void Adafruit_GFX_Button::initButton(
+ Adafruit_GFX *gfx, int16_t x, int16_t y, uint8_t w, uint8_t h,
+ uint16_t outline, uint16_t fill, uint16_t textcolor,
+ char *label, uint8_t textsize)
+{
+  _x            = x;
+  _y            = y;
+  _w            = w;
+  _h            = h;
+  _outlinecolor = outline;
+  _fillcolor    = fill;
+  _textcolor    = textcolor;
+  _textsize     = textsize;
+  _gfx          = gfx;
+  strncpy(_label, label, 9);
+  _label[9] = 0;
+}
+
+void Adafruit_GFX_Button::drawButton(boolean inverted) {
+  uint16_t fill, outline, text;
+
+  if(!inverted) {
+    fill    = _fillcolor;
+    outline = _outlinecolor;
+    text    = _textcolor;
+  } else {
+    fill    = _textcolor;
+    outline = _outlinecolor;
+    text    = _fillcolor;
+  }
+
+  _gfx->fillRoundRect(_x - (_w/2), _y - (_h/2), _w, _h, min(_w,_h)/4, fill);
+  _gfx->drawRoundRect(_x - (_w/2), _y - (_h/2), _w, _h, min(_w,_h)/4, outline);
+
+  _gfx->setCursor(_x - strlen(_label)*3*_textsize, _y-4*_textsize);
+  _gfx->setTextColor(text);
+  _gfx->setTextSize(_textsize);
+  _gfx->print(_label);
+}
+
+boolean Adafruit_GFX_Button::contains(uint16_t x, uint16_t y) {
+  if ((x < (_x - _w/2)) || (x > (_x + _w/2))) return false;
+  if ((y < (_y - _h/2)) || (y > (_y + _h/2))) return false;
+  return true;
+}
+
+void Adafruit_GFX_Button::press(boolean p) {
+  laststate = currstate;
+  currstate = p;
+}
+
+boolean Adafruit_GFX_Button::isPressed() { return currstate; }
+boolean Adafruit_GFX_Button::justPressed() { return (currstate && !laststate); }
+boolean Adafruit_GFX_Button::justReleased() { return (!currstate && laststate); }
+
+// -------------------------------------------------------------------------
+
+// GFXcanvas1 and GFXcanvas16 (currently a WIP, don't get too comfy with the
+// implementation) provide 1- and 16-bit offscreen canvases, the address of
+// which can be passed to drawBitmap() or pushColors() (the latter appears
+// to only be in Adafruit_TFTLCD at this time).  This is here mostly to
+// help with the recently-added proportionally-spaced fonts; adds a way to
+// refresh a section of the screen without a massive flickering clear-and-
+// redraw...but maybe you'll find other uses too.  VERY RAM-intensive, since
+// the buffer is in MCU memory and not the display driver...GXFcanvas1 might
+// be minimally useful on an Uno-class board, but this and GFXcanvas16 are
+// much more likely to require at least a Mega or various recent ARM-type
+// boards (recomment, as the text+bitmap draw can be pokey).  GFXcanvas1
+// requires 1 bit per pixel (rounded up to nearest byte per scanline),
+// GFXcanvas16 requires 2 bytes per pixel (no scanline pad).
+// NOT EXTENSIVELY TESTED YET.  MAY CONTAIN WORST BUGS KNOWN TO HUMANKIND.
+
+GFXcanvas1::GFXcanvas1(uint16_t w, uint16_t h) : Adafruit_GFX(w, h) {
+  uint16_t bytes = ((w + 7) / 8) * h;
+  if((buffer = (uint8_t *)malloc(bytes))) {
+    memset(buffer, 0, bytes);
+  }
+}
+
+GFXcanvas1::~GFXcanvas1(void) {
+  if(buffer) free(buffer);
+}
+
+uint8_t* GFXcanvas1::getBuffer(void) {
+  return buffer;
+}
+
+void GFXcanvas1::drawPixel(int16_t x, int16_t y, uint16_t color) {
+  // Bitmask tables of 0x80>>X and ~(0x80>>X), because X>>Y is slow on AVR
+  static const uint8_t PROGMEM
+    GFXsetBit[] = { 0x80, 0x40, 0x20, 0x10, 0x08, 0x04, 0x02, 0x01 },
+    GFXclrBit[] = { 0x7F, 0xBF, 0xDF, 0xEF, 0xF7, 0xFB, 0xFD, 0xFE };
+
+  if(buffer) {
+    if((x < 0) || (y < 0) || (x >= _width) || (y >= _height)) return;
+
+    int16_t t;
+    switch(rotation) {
+     case 1:
+      t = x;
+      x = WIDTH  - 1 - y;
+      y = t;
+      break;
+     case 2:
+      x = WIDTH  - 1 - x;
+      y = HEIGHT - 1 - y;
+      break;
+     case 3:
+      t = x;
+      x = y;
+      y = HEIGHT - 1 - t;
+      break;
+    }
+
+    uint8_t *ptr = &buffer[(x / 8) + y * ((WIDTH + 7) / 8)];
+    if(color) *ptr |= pgm_read_byte(&GFXsetBit[x & 7]);
+    else      *ptr &= pgm_read_byte(&GFXclrBit[x & 7]);
+  }
+}
+
+void GFXcanvas1::fillScreen(uint16_t color) {
+  if(buffer) {
+    uint16_t bytes = ((WIDTH + 7) / 8) * HEIGHT;
+    memset(buffer, color ? 0xFF : 0x00, bytes);
+  }
+}
+
+GFXcanvas16::GFXcanvas16(uint16_t w, uint16_t h) : Adafruit_GFX(w, h) {
+  uint16_t bytes = w * h * 2;
+  if((buffer = (uint16_t *)malloc(bytes))) {
+    memset(buffer, 0, bytes);
+  }
+}
+
+GFXcanvas16::~GFXcanvas16(void) {
+  if(buffer) free(buffer);
+}
+
+uint16_t* GFXcanvas16::getBuffer(void) {
+  return buffer;
+}
+
+void GFXcanvas16::drawPixel(int16_t x, int16_t y, uint16_t color) {
+  if(buffer) {
+    if((x < 0) || (y < 0) || (x >= _width) || (y >= _height)) return;
+
+    int16_t t;
+    switch(rotation) {
+     case 1:
+      t = x;
+      x = WIDTH  - 1 - y;
+      y = t;
+      break;
+     case 2:
+      x = WIDTH  - 1 - x;
+      y = HEIGHT - 1 - y;
+      break;
+     case 3:
+      t = x;
+      x = y;
+      y = HEIGHT - 1 - t;
+      break;
+    }
+
+    buffer[x + y * WIDTH] = color;
+  }
+}
+
+void GFXcanvas16::fillScreen(uint16_t color) {
+  if(buffer) {
+    uint8_t hi = color >> 8, lo = color & 0xFF;
+    if(hi == lo) {
+      memset(buffer, lo, WIDTH * HEIGHT * 2);
+    } else {
+      uint16_t i, pixels = WIDTH * HEIGHT;
+      for(i=0; i<pixels; i++) buffer[i] = color;
+    }
+  }
+}
+

--- a/Adafruit_GFX.h
+++ b/Adafruit_GFX.h
@@ -66,8 +66,12 @@ class Adafruit_GFX : public Print {
     setRotation(uint8_t r),
     cp437(boolean x=true),
     setFont(const GFXfont *f = NULL),
+    clearChangedGlyph(char *previous, char *current, 
+      int16_t x, int16_t y, uint16_t color),
     getTextBounds(char *str, int16_t x, int16_t y, int16_t *x1, 
-      int16_t *y1, uint16_t *w, uint16_t *h, uint8_t * glyphWidths = NULL),
+      int16_t *y1, uint16_t *w, uint16_t *h, uint8_t * glyphWidths),
+    getTextBounds(char *string, int16_t x, int16_t y,
+      int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h),
     getTextBounds(const __FlashStringHelper *s, int16_t x, int16_t y,
       int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h);
 

--- a/Adafruit_GFX.h
+++ b/Adafruit_GFX.h
@@ -1,1183 +1,157 @@
-/*
-This is the core graphics library for all our displays, providing a common
-set of graphics primitives (points, lines, circles, etc.).  It needs to be
-paired with a hardware-specific library for each display device we carry
-(to handle the lower-level functions).
+#ifndef _ADAFRUIT_GFX_H
+#define _ADAFRUIT_GFX_H
 
-Adafruit invests time and resources providing this open source code, please
-support Adafruit & open-source hardware by purchasing products from Adafruit!
-
-Copyright (c) 2013 Adafruit Industries.  All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
-- Redistributions of source code must retain the above copyright notice,
-  this list of conditions and the following disclaimer.
-- Redistributions in binary form must reproduce the above copyright notice,
-  this list of conditions and the following disclaimer in the documentation
-  and/or other materials provided with the distribution.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-POSSIBILITY OF SUCH DAMAGE.
-*/
-
-#ifdef __AVR__
- #include <avr/pgmspace.h>
-#elif defined(ESP8266)
- #include <pgmspace.h>
-#endif
-#include "Adafruit_GFX.h"
-#include "glcdfont.c"
-
-// Many (but maybe not all) non-AVR board installs define macros
-// for compatibility with existing PROGMEM-reading AVR code.
-// Do our own checks and defines here for good measure...
-
-#ifndef pgm_read_byte
- #define pgm_read_byte(addr) (*(const unsigned char *)(addr))
-#endif
-#ifndef pgm_read_word
- #define pgm_read_word(addr) (*(const unsigned short *)(addr))
-#endif
-#ifndef pgm_read_dword
- #define pgm_read_dword(addr) (*(const unsigned long *)(addr))
-#endif
-
-// Pointers are a peculiar case...typically 16-bit on AVR boards,
-// 32 bits elsewhere.  Try to accommodate both...
-
-#if !defined(__INT_MAX__) || (__INT_MAX__ > 0xFFFF)
- #define pgm_read_pointer(addr) ((void *)pgm_read_dword(addr))
+#if ARDUINO >= 100
+ #include "Arduino.h"
+ #include "Print.h"
 #else
- #define pgm_read_pointer(addr) ((void *)pgm_read_word(addr))
+ #include "WProgram.h"
 #endif
 
-#ifndef min
-#define min(a,b) (((a) < (b)) ? (a) : (b))
+#include "gfxfont.h"
+
+class Adafruit_GFX : public Print {
+
+ public:
+
+  Adafruit_GFX(int16_t w, int16_t h); // Constructor
+
+  // This MUST be defined by the subclass:
+  virtual void drawPixel(int16_t x, int16_t y, uint16_t color) = 0;
+
+  // These MAY be overridden by the subclass to provide device-specific
+  // optimized code.  Otherwise 'generic' versions are used.
+  virtual void
+    drawLine(int16_t x0, int16_t y0, int16_t x1, int16_t y1, uint16_t color),
+    drawFastVLine(int16_t x, int16_t y, int16_t h, uint16_t color),
+    drawFastHLine(int16_t x, int16_t y, int16_t w, uint16_t color),
+    drawRect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t color),
+    fillRect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t color),
+    fillScreen(uint16_t color),
+    invertDisplay(boolean i);
+
+  // These exist only with Adafruit_GFX (no subclass overrides)
+  void
+    drawCircle(int16_t x0, int16_t y0, int16_t r, uint16_t color),
+    drawCircleHelper(int16_t x0, int16_t y0, int16_t r, uint8_t cornername,
+      uint16_t color),
+    fillCircle(int16_t x0, int16_t y0, int16_t r, uint16_t color),
+    fillCircleHelper(int16_t x0, int16_t y0, int16_t r, uint8_t cornername,
+      int16_t delta, uint16_t color),
+    drawTriangle(int16_t x0, int16_t y0, int16_t x1, int16_t y1,
+      int16_t x2, int16_t y2, uint16_t color),
+    fillTriangle(int16_t x0, int16_t y0, int16_t x1, int16_t y1,
+      int16_t x2, int16_t y2, uint16_t color),
+    drawRoundRect(int16_t x0, int16_t y0, int16_t w, int16_t h,
+      int16_t radius, uint16_t color),
+    fillRoundRect(int16_t x0, int16_t y0, int16_t w, int16_t h,
+      int16_t radius, uint16_t color),
+    drawBitmap(int16_t x, int16_t y, const uint8_t *bitmap,
+      int16_t w, int16_t h, uint16_t color),
+    drawBitmap(int16_t x, int16_t y, const uint8_t *bitmap,
+      int16_t w, int16_t h, uint16_t color, uint16_t bg),
+    drawBitmap(int16_t x, int16_t y, uint8_t *bitmap,
+      int16_t w, int16_t h, uint16_t color),
+    drawBitmap(int16_t x, int16_t y, uint8_t *bitmap,
+      int16_t w, int16_t h, uint16_t color, uint16_t bg),
+    drawXBitmap(int16_t x, int16_t y, const uint8_t *bitmap,
+      int16_t w, int16_t h, uint16_t color),
+    drawChar(int16_t x, int16_t y, unsigned char c, uint16_t color,
+      uint16_t bg, uint8_t size),
+    setCursor(int16_t x, int16_t y),
+    setTextColor(uint16_t c),
+    setTextColor(uint16_t c, uint16_t bg),
+    setTextSize(uint8_t s),
+    setTextWrap(boolean w),
+    setRotation(uint8_t r),
+    cp437(boolean x=true),
+    setFont(const GFXfont *f = NULL),
+    clearChangedGlyph(char *previous, char *current, 
+      int16_t x, int16_t y, uint16_t color),
+    getTextBounds(char *str, int16_t x, int16_t y, int16_t *x1, 
+      int16_t *y1, uint16_t *w, uint16_t *h, uint8_t * glyphWidths = NULL),
+    getTextBounds(const __FlashStringHelper *s, int16_t x, int16_t y,
+      int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h);
+
+#if ARDUINO >= 100
+  virtual size_t write(uint8_t);
+#else
+  virtual void   write(uint8_t);
 #endif
 
-#ifndef _swap_int16_t
-#define _swap_int16_t(a, b) { int16_t t = a; a = b; b = t; }
-#endif
+  int16_t height(void) const;
+  int16_t width(void) const;
 
-Adafruit_GFX::Adafruit_GFX(int16_t w, int16_t h):
-  WIDTH(w), HEIGHT(h)
-{
-  _width    = WIDTH;
-  _height   = HEIGHT;
-  rotation  = 0;
-  cursor_y  = cursor_x    = 0;
-  textsize  = 1;
-  textcolor = textbgcolor = 0xFFFF;
-  wrap      = true;
-  _cp437    = false;
-  gfxFont   = NULL;
-}
+  uint8_t getRotation(void) const;
 
-// Draw a circle outline
-void Adafruit_GFX::drawCircle(int16_t x0, int16_t y0, int16_t r,
- uint16_t color) {
-  int16_t f = 1 - r;
-  int16_t ddF_x = 1;
-  int16_t ddF_y = -2 * r;
-  int16_t x = 0;
-  int16_t y = r;
+  // get current cursor position (get rotation safe maximum values, using: width() for x, height() for y)
+  int16_t getCursorX(void) const;
+  int16_t getCursorY(void) const;
 
-  drawPixel(x0  , y0+r, color);
-  drawPixel(x0  , y0-r, color);
-  drawPixel(x0+r, y0  , color);
-  drawPixel(x0-r, y0  , color);
-
-  while (x<y) {
-    if (f >= 0) {
-      y--;
-      ddF_y += 2;
-      f += ddF_y;
-    }
-    x++;
-    ddF_x += 2;
-    f += ddF_x;
-
-    drawPixel(x0 + x, y0 + y, color);
-    drawPixel(x0 - x, y0 + y, color);
-    drawPixel(x0 + x, y0 - y, color);
-    drawPixel(x0 - x, y0 - y, color);
-    drawPixel(x0 + y, y0 + x, color);
-    drawPixel(x0 - y, y0 + x, color);
-    drawPixel(x0 + y, y0 - x, color);
-    drawPixel(x0 - y, y0 - x, color);
-  }
-}
-
-void Adafruit_GFX::drawCircleHelper( int16_t x0, int16_t y0,
- int16_t r, uint8_t cornername, uint16_t color) {
-  int16_t f     = 1 - r;
-  int16_t ddF_x = 1;
-  int16_t ddF_y = -2 * r;
-  int16_t x     = 0;
-  int16_t y     = r;
-
-  while (x<y) {
-    if (f >= 0) {
-      y--;
-      ddF_y += 2;
-      f     += ddF_y;
-    }
-    x++;
-    ddF_x += 2;
-    f     += ddF_x;
-    if (cornername & 0x4) {
-      drawPixel(x0 + x, y0 + y, color);
-      drawPixel(x0 + y, y0 + x, color);
-    }
-    if (cornername & 0x2) {
-      drawPixel(x0 + x, y0 - y, color);
-      drawPixel(x0 + y, y0 - x, color);
-    }
-    if (cornername & 0x8) {
-      drawPixel(x0 - y, y0 + x, color);
-      drawPixel(x0 - x, y0 + y, color);
-    }
-    if (cornername & 0x1) {
-      drawPixel(x0 - y, y0 - x, color);
-      drawPixel(x0 - x, y0 - y, color);
-    }
-  }
-}
-
-void Adafruit_GFX::fillCircle(int16_t x0, int16_t y0, int16_t r,
- uint16_t color) {
-  drawFastVLine(x0, y0-r, 2*r+1, color);
-  fillCircleHelper(x0, y0, r, 3, 0, color);
-}
-
-// Used to do circles and roundrects
-void Adafruit_GFX::fillCircleHelper(int16_t x0, int16_t y0, int16_t r,
- uint8_t cornername, int16_t delta, uint16_t color) {
-
-  int16_t f     = 1 - r;
-  int16_t ddF_x = 1;
-  int16_t ddF_y = -2 * r;
-  int16_t x     = 0;
-  int16_t y     = r;
-
-  while (x<y) {
-    if (f >= 0) {
-      y--;
-      ddF_y += 2;
-      f     += ddF_y;
-    }
-    x++;
-    ddF_x += 2;
-    f     += ddF_x;
-
-    if (cornername & 0x1) {
-      drawFastVLine(x0+x, y0-y, 2*y+1+delta, color);
-      drawFastVLine(x0+y, y0-x, 2*x+1+delta, color);
-    }
-    if (cornername & 0x2) {
-      drawFastVLine(x0-x, y0-y, 2*y+1+delta, color);
-      drawFastVLine(x0-y, y0-x, 2*x+1+delta, color);
-    }
-  }
-}
-
-// Bresenham's algorithm - thx wikpedia
-void Adafruit_GFX::drawLine(int16_t x0, int16_t y0, int16_t x1, int16_t y1,
- uint16_t color) {
-  int16_t steep = abs(y1 - y0) > abs(x1 - x0);
-  if (steep) {
-    _swap_int16_t(x0, y0);
-    _swap_int16_t(x1, y1);
-  }
-
-  if (x0 > x1) {
-    _swap_int16_t(x0, x1);
-    _swap_int16_t(y0, y1);
-  }
-
-  int16_t dx, dy;
-  dx = x1 - x0;
-  dy = abs(y1 - y0);
-
-  int16_t err = dx / 2;
-  int16_t ystep;
-
-  if (y0 < y1) {
-    ystep = 1;
-  } else {
-    ystep = -1;
-  }
-
-  for (; x0<=x1; x0++) {
-    if (steep) {
-      drawPixel(y0, x0, color);
-    } else {
-      drawPixel(x0, y0, color);
-    }
-    err -= dy;
-    if (err < 0) {
-      y0 += ystep;
-      err += dx;
-    }
-  }
-}
-
-// Draw a rectangle
-void Adafruit_GFX::drawRect(int16_t x, int16_t y, int16_t w, int16_t h,
- uint16_t color) {
-  drawFastHLine(x, y, w, color);
-  drawFastHLine(x, y+h-1, w, color);
-  drawFastVLine(x, y, h, color);
-  drawFastVLine(x+w-1, y, h, color);
-}
-
-void Adafruit_GFX::drawFastVLine(int16_t x, int16_t y,
- int16_t h, uint16_t color) {
-  // Update in subclasses if desired!
-  drawLine(x, y, x, y+h-1, color);
-}
-
-void Adafruit_GFX::drawFastHLine(int16_t x, int16_t y,
- int16_t w, uint16_t color) {
-  // Update in subclasses if desired!
-  drawLine(x, y, x+w-1, y, color);
-}
-
-void Adafruit_GFX::fillRect(int16_t x, int16_t y, int16_t w, int16_t h,
- uint16_t color) {
-  // Update in subclasses if desired!
-  for (int16_t i=x; i<x+w; i++) {
-    drawFastVLine(i, y, h, color);
-  }
-}
-
-void Adafruit_GFX::fillScreen(uint16_t color) {
-  fillRect(0, 0, _width, _height, color);
-}
-
-// Draw a rounded rectangle
-void Adafruit_GFX::drawRoundRect(int16_t x, int16_t y, int16_t w,
- int16_t h, int16_t r, uint16_t color) {
-  // smarter version
-  drawFastHLine(x+r  , y    , w-2*r, color); // Top
-  drawFastHLine(x+r  , y+h-1, w-2*r, color); // Bottom
-  drawFastVLine(x    , y+r  , h-2*r, color); // Left
-  drawFastVLine(x+w-1, y+r  , h-2*r, color); // Right
-  // draw four corners
-  drawCircleHelper(x+r    , y+r    , r, 1, color);
-  drawCircleHelper(x+w-r-1, y+r    , r, 2, color);
-  drawCircleHelper(x+w-r-1, y+h-r-1, r, 4, color);
-  drawCircleHelper(x+r    , y+h-r-1, r, 8, color);
-}
-
-// Fill a rounded rectangle
-void Adafruit_GFX::fillRoundRect(int16_t x, int16_t y, int16_t w,
- int16_t h, int16_t r, uint16_t color) {
-  // smarter version
-  fillRect(x+r, y, w-2*r, h, color);
-
-  // draw four corners
-  fillCircleHelper(x+w-r-1, y+r, r, 1, h-2*r-1, color);
-  fillCircleHelper(x+r    , y+r, r, 2, h-2*r-1, color);
-}
-
-// Draw a triangle
-void Adafruit_GFX::drawTriangle(int16_t x0, int16_t y0,
- int16_t x1, int16_t y1, int16_t x2, int16_t y2, uint16_t color) {
-  drawLine(x0, y0, x1, y1, color);
-  drawLine(x1, y1, x2, y2, color);
-  drawLine(x2, y2, x0, y0, color);
-}
-
-// Fill a triangle
-void Adafruit_GFX::fillTriangle(int16_t x0, int16_t y0,
- int16_t x1, int16_t y1, int16_t x2, int16_t y2, uint16_t color) {
-
-  int16_t a, b, y, last;
-
-  // Sort coordinates by Y order (y2 >= y1 >= y0)
-  if (y0 > y1) {
-    _swap_int16_t(y0, y1); _swap_int16_t(x0, x1);
-  }
-  if (y1 > y2) {
-    _swap_int16_t(y2, y1); _swap_int16_t(x2, x1);
-  }
-  if (y0 > y1) {
-    _swap_int16_t(y0, y1); _swap_int16_t(x0, x1);
-  }
-
-  if(y0 == y2) { // Handle awkward all-on-same-line case as its own thing
-    a = b = x0;
-    if(x1 < a)      a = x1;
-    else if(x1 > b) b = x1;
-    if(x2 < a)      a = x2;
-    else if(x2 > b) b = x2;
-    drawFastHLine(a, y0, b-a+1, color);
-    return;
-  }
-
+ protected:
+  const int16_t
+    WIDTH, HEIGHT;   // This is the 'raw' display w/h - never changes
   int16_t
-    dx01 = x1 - x0,
-    dy01 = y1 - y0,
-    dx02 = x2 - x0,
-    dy02 = y2 - y0,
-    dx12 = x2 - x1,
-    dy12 = y2 - y1;
-  int32_t
-    sa   = 0,
-    sb   = 0;
-
-  // For upper part of triangle, find scanline crossings for segments
-  // 0-1 and 0-2.  If y1=y2 (flat-bottomed triangle), the scanline y1
-  // is included here (and second loop will be skipped, avoiding a /0
-  // error there), otherwise scanline y1 is skipped here and handled
-  // in the second loop...which also avoids a /0 error here if y0=y1
-  // (flat-topped triangle).
-  if(y1 == y2) last = y1;   // Include y1 scanline
-  else         last = y1-1; // Skip it
-
-  for(y=y0; y<=last; y++) {
-    a   = x0 + sa / dy01;
-    b   = x0 + sb / dy02;
-    sa += dx01;
-    sb += dx02;
-    /* longhand:
-    a = x0 + (x1 - x0) * (y - y0) / (y1 - y0);
-    b = x0 + (x2 - x0) * (y - y0) / (y2 - y0);
-    */
-    if(a > b) _swap_int16_t(a,b);
-    drawFastHLine(a, y, b-a+1, color);
-  }
-
-  // For lower part of triangle, find scanline crossings for segments
-  // 0-2 and 1-2.  This loop is skipped if y1=y2.
-  sa = dx12 * (y - y1);
-  sb = dx02 * (y - y0);
-  for(; y<=y2; y++) {
-    a   = x1 + sa / dy12;
-    b   = x0 + sb / dy02;
-    sa += dx12;
-    sb += dx02;
-    /* longhand:
-    a = x1 + (x2 - x1) * (y - y1) / (y2 - y1);
-    b = x0 + (x2 - x0) * (y - y0) / (y2 - y0);
-    */
-    if(a > b) _swap_int16_t(a,b);
-    drawFastHLine(a, y, b-a+1, color);
-  }
-}
-
-// Draw a 1-bit image (bitmap) at the specified (x,y) position from the
-// provided bitmap buffer (must be PROGMEM memory) using the specified
-// foreground color (unset bits are transparent).
-void Adafruit_GFX::drawBitmap(int16_t x, int16_t y,
- const uint8_t *bitmap, int16_t w, int16_t h, uint16_t color) {
-
-  int16_t i, j, byteWidth = (w + 7) / 8;
-  uint8_t byte = 0;
-
-  for(j=0; j<h; j++) {
-    for(i=0; i<w; i++) {
-      if(i & 7) byte <<= 1;
-      else      byte   = pgm_read_byte(bitmap + j * byteWidth + i / 8);
-      if(byte & 0x80) drawPixel(x+i, y+j, color);
-    }
-  }
-}
-
-// Draw a 1-bit image (bitmap) at the specified (x,y) position from the
-// provided bitmap buffer (must be PROGMEM memory) using the specified
-// foreground (for set bits) and background (for clear bits) colors.
-void Adafruit_GFX::drawBitmap(int16_t x, int16_t y,
- const uint8_t *bitmap, int16_t w, int16_t h, uint16_t color, uint16_t bg) {
-
-  int16_t i, j, byteWidth = (w + 7) / 8;
-  uint8_t byte;
-
-  for(j=0; j<h; j++) {
-    for(i=0; i<w; i++ ) {
-      if(i & 7) byte <<= 1;
-      else      byte   = pgm_read_byte(bitmap + j * byteWidth + i / 8);
-      if(byte & 0x80) drawPixel(x+i, y+j, color);
-      else            drawPixel(x+i, y+j, bg);
-    }
-  }
-}
-
-// drawBitmap() variant for RAM-resident (not PROGMEM) bitmaps.
-void Adafruit_GFX::drawBitmap(int16_t x, int16_t y,
- uint8_t *bitmap, int16_t w, int16_t h, uint16_t color) {
-
-  int16_t i, j, byteWidth = (w + 7) / 8;
-  uint8_t byte;
-
-  for(j=0; j<h; j++) {
-    for(i=0; i<w; i++ ) {
-      if(i & 7) byte <<= 1;
-      else      byte   = bitmap[j * byteWidth + i / 8];
-      if(byte & 0x80) drawPixel(x+i, y+j, color);
-    }
-  }
-}
-
-// drawBitmap() variant w/background for RAM-resident (not PROGMEM) bitmaps.
-void Adafruit_GFX::drawBitmap(int16_t x, int16_t y,
- uint8_t *bitmap, int16_t w, int16_t h, uint16_t color, uint16_t bg) {
-
-  int16_t i, j, byteWidth = (w + 7) / 8;
-  uint8_t byte;
-
-  for(j=0; j<h; j++) {
-    for(i=0; i<w; i++ ) {
-      if(i & 7) byte <<= 1;
-      else      byte   = bitmap[j * byteWidth + i / 8];
-      if(byte & 0x80) drawPixel(x+i, y+j, color);
-      else            drawPixel(x+i, y+j, bg);
-    }
-  }
-}
-
-//Draw XBitMap Files (*.xbm), exported from GIMP,
-//Usage: Export from GIMP to *.xbm, rename *.xbm to *.c and open in editor.
-//C Array can be directly used with this function
-void Adafruit_GFX::drawXBitmap(int16_t x, int16_t y,
- const uint8_t *bitmap, int16_t w, int16_t h, uint16_t color) {
-
-  int16_t i, j, byteWidth = (w + 7) / 8;
-  uint8_t byte;
-
-  for(j=0; j<h; j++) {
-    for(i=0; i<w; i++ ) {
-      if(i & 7) byte >>= 1;
-      else      byte   = pgm_read_byte(bitmap + j * byteWidth + i / 8);
-      if(byte & 0x01) drawPixel(x+i, y+j, color);
-    }
-  }
-}
-
-#if ARDUINO >= 100
-size_t Adafruit_GFX::write(uint8_t c) {
-#else
-void Adafruit_GFX::write(uint8_t c) {
-#endif
-
-  if(!gfxFont) { // 'Classic' built-in font
-
-    if(c == '\n') {
-      cursor_y += textsize*8;
-      cursor_x  = 0;
-    } else if(c == '\r') {
-      // skip em
-    } else {
-      if(wrap && ((cursor_x + textsize * 6) >= _width)) { // Heading off edge?
-        cursor_x  = 0;            // Reset x to zero
-        cursor_y += textsize * 8; // Advance y one line
-      }
-      drawChar(cursor_x, cursor_y, c, textcolor, textbgcolor, textsize);
-      cursor_x += textsize * 6;
-    }
-
-  } else { // Custom font
-
-    if(c == '\n') {
-      cursor_x  = 0;
-      cursor_y += (int16_t)textsize *
-                  (uint8_t)pgm_read_byte(&gfxFont->yAdvance);
-    } else if(c != '\r') {
-      uint8_t first = pgm_read_byte(&gfxFont->first);
-      if((c >= first) && (c <= (uint8_t)pgm_read_byte(&gfxFont->last))) {
-        uint8_t   c2    = c - pgm_read_byte(&gfxFont->first);
-        GFXglyph *glyph = &(((GFXglyph *)pgm_read_pointer(&gfxFont->glyph))[c2]);
-        uint8_t   w     = pgm_read_byte(&glyph->width),
-                  h     = pgm_read_byte(&glyph->height);
-        if((w > 0) && (h > 0)) { // Is there an associated bitmap?
-          int16_t xo = (int8_t)pgm_read_byte(&glyph->xOffset); // sic
-          if(wrap && ((cursor_x + textsize * (xo + w)) >= _width)) {
-            // Drawing character would go off right edge; wrap to new line
-            cursor_x  = 0;
-            cursor_y += (int16_t)textsize *
-                        (uint8_t)pgm_read_byte(&gfxFont->yAdvance);
-          }
-          drawChar(cursor_x, cursor_y, c, textcolor, textbgcolor, textsize);
-        }
-        cursor_x += pgm_read_byte(&glyph->xAdvance) * (int16_t)textsize;
-      }
-    }
-
-  }
-#if ARDUINO >= 100
-  return 1;
-#endif
-}
-
-// Draw a character
-void Adafruit_GFX::drawChar(int16_t x, int16_t y, unsigned char c,
- uint16_t color, uint16_t bg, uint8_t size) {
-
-  if(!gfxFont) { // 'Classic' built-in font
-
-    if((x >= _width)            || // Clip right
-       (y >= _height)           || // Clip bottom
-       ((x + 6 * size - 1) < 0) || // Clip left
-       ((y + 8 * size - 1) < 0))   // Clip top
-      return;
-
-    if(!_cp437 && (c >= 176)) c++; // Handle 'classic' charset behavior
-
-    for(int8_t i=0; i<6; i++ ) {
-      uint8_t line;
-      if(i < 5) line = pgm_read_byte(font+(c*5)+i);
-      else      line = 0x0;
-      for(int8_t j=0; j<8; j++, line >>= 1) {
-        if(line & 0x1) {
-          if(size == 1) drawPixel(x+i, y+j, color);
-          else          fillRect(x+(i*size), y+(j*size), size, size, color);
-        } else if(bg != color) {
-          if(size == 1) drawPixel(x+i, y+j, bg);
-          else          fillRect(x+i*size, y+j*size, size, size, bg);
-        }
-      }
-    }
-
-  } else { // Custom font
-
-    // Character is assumed previously filtered by write() to eliminate
-    // newlines, returns, non-printable characters, etc.  Calling drawChar()
-    // directly with 'bad' characters of font may cause mayhem!
-
-    c -= pgm_read_byte(&gfxFont->first);
-    GFXglyph *glyph  = &(((GFXglyph *)pgm_read_pointer(&gfxFont->glyph))[c]);
-    uint8_t  *bitmap = (uint8_t *)pgm_read_pointer(&gfxFont->bitmap);
-
-    uint16_t bo = pgm_read_word(&glyph->bitmapOffset);
-    uint8_t  w  = pgm_read_byte(&glyph->width),
-             h  = pgm_read_byte(&glyph->height);//,
-             //xa = pgm_read_byte(&glyph->xAdvance);
-    int8_t   xo = pgm_read_byte(&glyph->xOffset),
-             yo = pgm_read_byte(&glyph->yOffset);
-    uint8_t  xx = 0, yy = 0, bits = 0, bit = 0;
-    int16_t  xo16 = 0, yo16 = 0;
-
-    if(size > 1) {
-      xo16 = xo;
-      yo16 = yo;
-    }
-
-    // Todo: Add character clipping here
-
-    // NOTE: THERE IS NO 'BACKGROUND' COLOR OPTION ON CUSTOM FONTS.
-    // THIS IS ON PURPOSE AND BY DESIGN.  The background color feature
-    // has typically been used with the 'classic' font to overwrite old
-    // screen contents with new data.  This ONLY works because the
-    // characters are a uniform size; it's not a sensible thing to do with
-    // proportionally-spaced fonts with glyphs of varying sizes (and that
-    // may overlap).  To replace previously-drawn text when using a custom
-    // font, use the getTextBounds() function to determine the smallest
-    // rectangle encompassing a string, erase the area with fillRect(),
-    // then draw new text.  This WILL infortunately 'blink' the text, but
-    // is unavoidable.  Drawing 'background' pixels will NOT fix this,
-    // only creates a new set of problems.  Have an idea to work around
-    // this (a canvas object type for MCUs that can afford the RAM and
-    // displays supporting setAddrWindow() and pushColors()), but haven't
-    // implemented this yet.
-
-    for(yy=0; yy<h; yy++) {
-      for(xx=0; xx<w; xx++) {
-        if(!(bit++ & 7)) {
-          bits = pgm_read_byte(&bitmap[bo++]);
-        }
-        if(bits & 0x80) {
-          if(size == 1) {
-            drawPixel(x+xo+xx, y+yo+yy, color);
-          } else {
-            fillRect(x+(xo16+xx)*size, y+(yo16+yy)*size, size, size, color);
-          }
-        }
-        bits <<= 1;
-      }
-    }
-
-  } // End classic vs custom font
-}
-
-void Adafruit_GFX::setCursor(int16_t x, int16_t y) {
-  cursor_x = x;
-  cursor_y = y;
-}
-
-int16_t Adafruit_GFX::getCursorX(void) const {
-  return cursor_x;
-}
-
-int16_t Adafruit_GFX::getCursorY(void) const {
-  return cursor_y;
-}
-
-void Adafruit_GFX::setTextSize(uint8_t s) {
-  textsize = (s > 0) ? s : 1;
-}
-
-void Adafruit_GFX::setTextColor(uint16_t c) {
-  // For 'transparent' background, we'll set the bg
-  // to the same as fg instead of using a flag
-  textcolor = textbgcolor = c;
-}
-
-void Adafruit_GFX::setTextColor(uint16_t c, uint16_t b) {
-  textcolor   = c;
-  textbgcolor = b;
-}
-
-void Adafruit_GFX::setTextWrap(boolean w) {
-  wrap = w;
-}
-
-uint8_t Adafruit_GFX::getRotation(void) const {
-  return rotation;
-}
-
-void Adafruit_GFX::setRotation(uint8_t x) {
-  rotation = (x & 3);
-  switch(rotation) {
-   case 0:
-   case 2:
-    _width  = WIDTH;
-    _height = HEIGHT;
-    break;
-   case 1:
-   case 3:
-    _width  = HEIGHT;
-    _height = WIDTH;
-    break;
-  }
-}
-
-// Enable (or disable) Code Page 437-compatible charset.
-// There was an error in glcdfont.c for the longest time -- one character
-// (#176, the 'light shade' block) was missing -- this threw off the index
-// of every character that followed it.  But a TON of code has been written
-// with the erroneous character indices.  By default, the library uses the
-// original 'wrong' behavior and old sketches will still work.  Pass 'true'
-// to this function to use correct CP437 character values in your code.
-void Adafruit_GFX::cp437(boolean x) {
-  _cp437 = x;
-}
-
-void Adafruit_GFX::setFont(const GFXfont *f) {
-  if(f) {          // Font struct pointer passed in?
-    if(!gfxFont) { // And no current font struct?
-      // Switching from classic to new font behavior.
-      // Move cursor pos down 6 pixels so it's on baseline.
-      cursor_y += 6;
-    }
-  } else if(gfxFont) { // NULL passed.  Current font struct defined?
-    // Switching from new to classic font behavior.
-    // Move cursor pos up 6 pixels so it's at top-left of char.
-    cursor_y -= 6;
-  }
-  gfxFont = (GFXfont *)f;
-}
-// Takes two char array, checks wich glyph has changed within
-// the current one, and clears the background of just that glyph
-void Adafruit_GFX::clearChangedGlyph(char *previous, char *current, 
-  int16_t x, int16_t y, uint16_t color) {
-
-  int16_t  x1, y1;
-  uint16_t w, h;
-  uint8_t length = strlen(previous);
-  uint8_t glyphWidths[length];
-
-  getTextBounds(previous, x, y, &x1, &y1, &w, &h, glyphWidths);
-
-  uint8_t cursor_x = x1;
-  for(uint8_t i = 0; i < length; i++) {
-    if(previous[i] != current[i]) {
-      fillRect(cursor_x, y1, glyphWidths[i], h, color);
-    }
-    cursor_x += glyphWidths[i];
-  }
-}
-
-// Pass string and a cursor position, returns UL corner and W,H.
-void Adafruit_GFX::getTextBounds(char *str, int16_t x, int16_t y,
- int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h, uint8_t * glyphWidths) {
-  uint8_t c; // Current character
-
-  *x1 = x;
-  *y1 = y;
-  *w  = *h = 0;
-
-  if(gfxFont) {
-
-    GFXglyph *glyph;
-    uint8_t   first = pgm_read_byte(&gfxFont->first),
-              last  = pgm_read_byte(&gfxFont->last),
-              gw, gh, xa;
-    int8_t    xo, yo;
-    int16_t   minx = _width, miny = _height, maxx = -1, maxy = -1,
-              gx1, gy1, gx2, gy2, ts = (int16_t)textsize,
-              ya = ts * (uint8_t)pgm_read_byte(&gfxFont->yAdvance);
-
-    while((c = *str++)) {
-      if(c != '\n') { // Not a newline
-        if(c != '\r') { // Not a carriage return, is normal char
-          if((c >= first) && (c <= last)) { // Char present in current font
-            c    -= first;
-            glyph = &(((GFXglyph *)pgm_read_pointer(&gfxFont->glyph))[c]);
-            gw    = pgm_read_byte(&glyph->width);
-            
-            gh    = pgm_read_byte(&glyph->height);
-            xa    = pgm_read_byte(&glyph->xAdvance);
-            xo    = pgm_read_byte(&glyph->xOffset);
-            yo    = pgm_read_byte(&glyph->yOffset);
-            if(wrap && ((x + (((int16_t)xo + gw) * ts)) >= _width)) {
-              // Line wrap
-              x  = 0;  // Reset x to 0
-              y += ya; // Advance y by 1 line
-            }
-            gx1 = x   + xo * ts;
-            gy1 = y   + yo * ts;
-            gx2 = gx1 + gw * ts - 1;
-            gy2 = gy1 + gh * ts - 1;
-            if(gx1 < minx) minx = gx1;
-            if(gy1 < miny) miny = gy1;
-            if(gx2 > maxx) maxx = gx2;
-            if(gy2 > maxy) maxy = gy2;
-            x += xa * ts;
-
-            *glyphWidths++ = xa * ts;
-          }
-        } // Carriage return = do nothing
-      } else { // Newline
-        x  = 0;  // Reset x
-        y += ya; // Advance y by 1 line
-      }
-    }
-    // End of string
-    *x1 = minx;
-    *y1 = miny;
-    if(maxx >= minx) *w  = maxx - minx + 1;
-    if(maxy >= miny) *h  = maxy - miny + 1;
-
-  } else { // Default font
-
-    uint16_t lineWidth = 0, maxWidth = 0; // Width of current, all lines
-
-    while((c = *str++)) {
-      if(c != '\n') { // Not a newline
-        if(c != '\r') { // Not a carriage return, is normal char
-          if(wrap && ((x + textsize * 6) >= _width)) {
-            x  = 0;            // Reset x to 0
-            y += textsize * 8; // Advance y by 1 line
-            if(lineWidth > maxWidth) maxWidth = lineWidth; // Save widest line
-            lineWidth  = textsize * 6; // First char on new line
-          } else { // No line wrap, just keep incrementing X
-            lineWidth += textsize * 6; // Includes interchar x gap
-          }
-          *glyphWidths++ = textsize * 6;
-        } // Carriage return = do nothing
-      } else { // Newline
-        x  = 0;            // Reset x to 0
-        y += textsize * 8; // Advance y by 1 line
-        if(lineWidth > maxWidth) maxWidth = lineWidth; // Save widest line
-        lineWidth = 0;     // Reset lineWidth for new line
-      }
-    }
-    // End of string
-    if(lineWidth) y += textsize * 8; // Add height of last (or only) line
-    *w = maxWidth - 1;               // Don't include last interchar x gap
-    *h = y - *y1;
-  } // End classic vs custom font
-}
-
-// Pass string and a cursor position, returns UL corner and W,H.
-void Adafruit_GFX::getTextBounds(char *str, int16_t x, int16_t y,
- int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h) {
-  uint8_t c; // Current character
-
-  *x1 = x;
-  *y1 = y;
-  *w  = *h = 0;
-
-  if(gfxFont) {
-
-    GFXglyph *glyph;
-    uint8_t   first = pgm_read_byte(&gfxFont->first),
-              last  = pgm_read_byte(&gfxFont->last),
-              gw, gh, xa;
-    int8_t    xo, yo;
-    int16_t   minx = _width, miny = _height, maxx = -1, maxy = -1,
-              gx1, gy1, gx2, gy2, ts = (int16_t)textsize,
-              ya = ts * (uint8_t)pgm_read_byte(&gfxFont->yAdvance);
-
-    while((c = *str++)) {
-      if(c != '\n') { // Not a newline
-        if(c != '\r') { // Not a carriage return, is normal char
-          if((c >= first) && (c <= last)) { // Char present in current font
-            c    -= first;
-            glyph = &(((GFXglyph *)pgm_read_pointer(&gfxFont->glyph))[c]);
-            gw    = pgm_read_byte(&glyph->width);
-            gh    = pgm_read_byte(&glyph->height);
-            xa    = pgm_read_byte(&glyph->xAdvance);
-            xo    = pgm_read_byte(&glyph->xOffset);
-            yo    = pgm_read_byte(&glyph->yOffset);
-            if(wrap && ((x + (((int16_t)xo + gw) * ts)) >= _width)) {
-              // Line wrap
-              x  = 0;  // Reset x to 0
-              y += ya; // Advance y by 1 line
-            }
-            gx1 = x   + xo * ts;
-            gy1 = y   + yo * ts;
-            gx2 = gx1 + gw * ts - 1;
-            gy2 = gy1 + gh * ts - 1;
-            if(gx1 < minx) minx = gx1;
-            if(gy1 < miny) miny = gy1;
-            if(gx2 > maxx) maxx = gx2;
-            if(gy2 > maxy) maxy = gy2;
-            x += xa * ts;
-          }
-        } // Carriage return = do nothing
-      } else { // Newline
-        x  = 0;  // Reset x
-        y += ya; // Advance y by 1 line
-      }
-    }
-    // End of string
-    *x1 = minx;
-    *y1 = miny;
-    if(maxx >= minx) *w  = maxx - minx + 1;
-    if(maxy >= miny) *h  = maxy - miny + 1;
-
-  } else { // Default font
-
-    uint16_t lineWidth = 0, maxWidth = 0; // Width of current, all lines
-
-    while((c = *str++)) {
-      if(c != '\n') { // Not a newline
-        if(c != '\r') { // Not a carriage return, is normal char
-          if(wrap && ((x + textsize * 6) >= _width)) {
-            x  = 0;            // Reset x to 0
-            y += textsize * 8; // Advance y by 1 line
-            if(lineWidth > maxWidth) maxWidth = lineWidth; // Save widest line
-            lineWidth  = textsize * 6; // First char on new line
-          } else { // No line wrap, just keep incrementing X
-            lineWidth += textsize * 6; // Includes interchar x gap
-          }
-        } // Carriage return = do nothing
-      } else { // Newline
-        x  = 0;            // Reset x to 0
-        y += textsize * 8; // Advance y by 1 line
-        if(lineWidth > maxWidth) maxWidth = lineWidth; // Save widest line
-        lineWidth = 0;     // Reset lineWidth for new line
-      }
-    }
-    // End of string
-    if(lineWidth) y += textsize * 8; // Add height of last (or only) line
-    *w = maxWidth - 1;               // Don't include last interchar x gap
-    *h = y - *y1;
-
-  } // End classic vs custom font
-}
-
-// Same as above, but for PROGMEM strings
-void Adafruit_GFX::getTextBounds(const __FlashStringHelper *str,
- int16_t x, int16_t y, int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h) {
-  uint8_t *s = (uint8_t *)str, c;
-
-  *x1 = x;
-  *y1 = y;
-  *w  = *h = 0;
-
-  if(gfxFont) {
-
-    GFXglyph *glyph;
-    uint8_t   first = pgm_read_byte(&gfxFont->first),
-              last  = pgm_read_byte(&gfxFont->last),
-              gw, gh, xa;
-    int8_t    xo, yo;
-    int16_t   minx = _width, miny = _height, maxx = -1, maxy = -1,
-              gx1, gy1, gx2, gy2, ts = (int16_t)textsize,
-              ya = ts * (uint8_t)pgm_read_byte(&gfxFont->yAdvance);
-
-    while((c = pgm_read_byte(s++))) {
-      if(c != '\n') { // Not a newline
-        if(c != '\r') { // Not a carriage return, is normal char
-          if((c >= first) && (c <= last)) { // Char present in current font
-            c    -= first;
-            glyph = &(((GFXglyph *)pgm_read_pointer(&gfxFont->glyph))[c]);
-            gw    = pgm_read_byte(&glyph->width);
-            gh    = pgm_read_byte(&glyph->height);
-            xa    = pgm_read_byte(&glyph->xAdvance);
-            xo    = pgm_read_byte(&glyph->xOffset);
-            yo    = pgm_read_byte(&glyph->yOffset);
-            if(wrap && ((x + (((int16_t)xo + gw) * ts)) >= _width)) {
-              // Line wrap
-              x  = 0;  // Reset x to 0
-              y += ya; // Advance y by 1 line
-            }
-            gx1 = x   + xo * ts;
-            gy1 = y   + yo * ts;
-            gx2 = gx1 + gw * ts - 1;
-            gy2 = gy1 + gh * ts - 1;
-            if(gx1 < minx) minx = gx1;
-            if(gy1 < miny) miny = gy1;
-            if(gx2 > maxx) maxx = gx2;
-            if(gy2 > maxy) maxy = gy2;
-            x += xa * ts;
-          }
-        } // Carriage return = do nothing
-      } else { // Newline
-        x  = 0;  // Reset x
-        y += ya; // Advance y by 1 line
-      }
-    }
-    // End of string
-    *x1 = minx;
-    *y1 = miny;
-    if(maxx >= minx) *w  = maxx - minx + 1;
-    if(maxy >= miny) *h  = maxy - miny + 1;
-
-  } else { // Default font
-
-    uint16_t lineWidth = 0, maxWidth = 0; // Width of current, all lines
-
-    while((c = pgm_read_byte(s++))) {
-      if(c != '\n') { // Not a newline
-        if(c != '\r') { // Not a carriage return, is normal char
-          if(wrap && ((x + textsize * 6) >= _width)) {
-            x  = 0;            // Reset x to 0
-            y += textsize * 8; // Advance y by 1 line
-            if(lineWidth > maxWidth) maxWidth = lineWidth; // Save widest line
-            lineWidth  = textsize * 6; // First char on new line
-          } else { // No line wrap, just keep incrementing X
-            lineWidth += textsize * 6; // Includes interchar x gap
-          }
-        } // Carriage return = do nothing
-      } else { // Newline
-        x  = 0;            // Reset x to 0
-        y += textsize * 8; // Advance y by 1 line
-        if(lineWidth > maxWidth) maxWidth = lineWidth; // Save widest line
-        lineWidth = 0;     // Reset lineWidth for new line
-      }
-    }
-    // End of string
-    if(lineWidth) y += textsize * 8; // Add height of last (or only) line
-    *w = maxWidth - 1;               // Don't include last interchar x gap
-    *h = y - *y1;
-
-  } // End classic vs custom font
-}
-
-// Return the size of the display (per current rotation)
-int16_t Adafruit_GFX::width(void) const {
-  return _width;
-}
-
-int16_t Adafruit_GFX::height(void) const {
-  return _height;
-}
-
-/*
-void Adafruit_GFX::invertDisplay(boolean i) {
-  // Do nothing, must be subclassed if supported by hardware
-}
-*/
-
-/***************************************************************************/
-// code for the GFX button UI element
-
-Adafruit_GFX_Button::Adafruit_GFX_Button(void) {
-  _gfx = 0;
-}
-
-void Adafruit_GFX_Button::initButton(
- Adafruit_GFX *gfx, int16_t x, int16_t y, uint8_t w, uint8_t h,
- uint16_t outline, uint16_t fill, uint16_t textcolor,
- char *label, uint8_t textsize)
-{
-  _x            = x;
-  _y            = y;
-  _w            = w;
-  _h            = h;
-  _outlinecolor = outline;
-  _fillcolor    = fill;
-  _textcolor    = textcolor;
-  _textsize     = textsize;
-  _gfx          = gfx;
-  strncpy(_label, label, 9);
-  _label[9] = 0;
-}
-
-void Adafruit_GFX_Button::drawButton(boolean inverted) {
-  uint16_t fill, outline, text;
-
-  if(!inverted) {
-    fill    = _fillcolor;
-    outline = _outlinecolor;
-    text    = _textcolor;
-  } else {
-    fill    = _textcolor;
-    outline = _outlinecolor;
-    text    = _fillcolor;
-  }
-
-  _gfx->fillRoundRect(_x - (_w/2), _y - (_h/2), _w, _h, min(_w,_h)/4, fill);
-  _gfx->drawRoundRect(_x - (_w/2), _y - (_h/2), _w, _h, min(_w,_h)/4, outline);
-
-  _gfx->setCursor(_x - strlen(_label)*3*_textsize, _y-4*_textsize);
-  _gfx->setTextColor(text);
-  _gfx->setTextSize(_textsize);
-  _gfx->print(_label);
-}
-
-boolean Adafruit_GFX_Button::contains(uint16_t x, uint16_t y) {
-  if ((x < (_x - _w/2)) || (x > (_x + _w/2))) return false;
-  if ((y < (_y - _h/2)) || (y > (_y + _h/2))) return false;
-  return true;
-}
-
-void Adafruit_GFX_Button::press(boolean p) {
-  laststate = currstate;
-  currstate = p;
-}
-
-boolean Adafruit_GFX_Button::isPressed() { return currstate; }
-boolean Adafruit_GFX_Button::justPressed() { return (currstate && !laststate); }
-boolean Adafruit_GFX_Button::justReleased() { return (!currstate && laststate); }
-
-// -------------------------------------------------------------------------
-
-// GFXcanvas1 and GFXcanvas16 (currently a WIP, don't get too comfy with the
-// implementation) provide 1- and 16-bit offscreen canvases, the address of
-// which can be passed to drawBitmap() or pushColors() (the latter appears
-// to only be in Adafruit_TFTLCD at this time).  This is here mostly to
-// help with the recently-added proportionally-spaced fonts; adds a way to
-// refresh a section of the screen without a massive flickering clear-and-
-// redraw...but maybe you'll find other uses too.  VERY RAM-intensive, since
-// the buffer is in MCU memory and not the display driver...GXFcanvas1 might
-// be minimally useful on an Uno-class board, but this and GFXcanvas16 are
-// much more likely to require at least a Mega or various recent ARM-type
-// boards (recomment, as the text+bitmap draw can be pokey).  GFXcanvas1
-// requires 1 bit per pixel (rounded up to nearest byte per scanline),
-// GFXcanvas16 requires 2 bytes per pixel (no scanline pad).
-// NOT EXTENSIVELY TESTED YET.  MAY CONTAIN WORST BUGS KNOWN TO HUMANKIND.
-
-GFXcanvas1::GFXcanvas1(uint16_t w, uint16_t h) : Adafruit_GFX(w, h) {
-  uint16_t bytes = ((w + 7) / 8) * h;
-  if((buffer = (uint8_t *)malloc(bytes))) {
-    memset(buffer, 0, bytes);
-  }
-}
-
-GFXcanvas1::~GFXcanvas1(void) {
-  if(buffer) free(buffer);
-}
-
-uint8_t* GFXcanvas1::getBuffer(void) {
-  return buffer;
-}
-
-void GFXcanvas1::drawPixel(int16_t x, int16_t y, uint16_t color) {
-  // Bitmask tables of 0x80>>X and ~(0x80>>X), because X>>Y is slow on AVR
-  static const uint8_t PROGMEM
-    GFXsetBit[] = { 0x80, 0x40, 0x20, 0x10, 0x08, 0x04, 0x02, 0x01 },
-    GFXclrBit[] = { 0x7F, 0xBF, 0xDF, 0xEF, 0xF7, 0xFB, 0xFD, 0xFE };
-
-  if(buffer) {
-    if((x < 0) || (y < 0) || (x >= _width) || (y >= _height)) return;
-
-    int16_t t;
-    switch(rotation) {
-     case 1:
-      t = x;
-      x = WIDTH  - 1 - y;
-      y = t;
-      break;
-     case 2:
-      x = WIDTH  - 1 - x;
-      y = HEIGHT - 1 - y;
-      break;
-     case 3:
-      t = x;
-      x = y;
-      y = HEIGHT - 1 - t;
-      break;
-    }
-
-    uint8_t *ptr = &buffer[(x / 8) + y * ((WIDTH + 7) / 8)];
-    if(color) *ptr |= pgm_read_byte(&GFXsetBit[x & 7]);
-    else      *ptr &= pgm_read_byte(&GFXclrBit[x & 7]);
-  }
-}
-
-void GFXcanvas1::fillScreen(uint16_t color) {
-  if(buffer) {
-    uint16_t bytes = ((WIDTH + 7) / 8) * HEIGHT;
-    memset(buffer, color ? 0xFF : 0x00, bytes);
-  }
-}
-
-GFXcanvas16::GFXcanvas16(uint16_t w, uint16_t h) : Adafruit_GFX(w, h) {
-  uint16_t bytes = w * h * 2;
-  if((buffer = (uint16_t *)malloc(bytes))) {
-    memset(buffer, 0, bytes);
-  }
-}
-
-GFXcanvas16::~GFXcanvas16(void) {
-  if(buffer) free(buffer);
-}
-
-uint16_t* GFXcanvas16::getBuffer(void) {
-  return buffer;
-}
-
-void GFXcanvas16::drawPixel(int16_t x, int16_t y, uint16_t color) {
-  if(buffer) {
-    if((x < 0) || (y < 0) || (x >= _width) || (y >= _height)) return;
-
-    int16_t t;
-    switch(rotation) {
-     case 1:
-      t = x;
-      x = WIDTH  - 1 - y;
-      y = t;
-      break;
-     case 2:
-      x = WIDTH  - 1 - x;
-      y = HEIGHT - 1 - y;
-      break;
-     case 3:
-      t = x;
-      x = y;
-      y = HEIGHT - 1 - t;
-      break;
-    }
-
-    buffer[x + y * WIDTH] = color;
-  }
-}
-
-void GFXcanvas16::fillScreen(uint16_t color) {
-  if(buffer) {
-    uint8_t hi = color >> 8, lo = color & 0xFF;
-    if(hi == lo) {
-      memset(buffer, lo, WIDTH * HEIGHT * 2);
-    } else {
-      uint16_t i, pixels = WIDTH * HEIGHT;
-      for(i=0; i<pixels; i++) buffer[i] = color;
-    }
-  }
-}
-
+    _width, _height, // Display w/h as modified by current rotation
+    cursor_x, cursor_y;
+  uint16_t
+    textcolor, textbgcolor;
+  uint8_t
+    textsize,
+    rotation;
+  boolean
+    wrap,   // If set, 'wrap' text at right edge of display
+    _cp437; // If set, use correct CP437 charset (default is off)
+  GFXfont
+    *gfxFont;
+};
+
+class Adafruit_GFX_Button {
+
+ public:
+  Adafruit_GFX_Button(void);
+  void initButton(Adafruit_GFX *gfx, int16_t x, int16_t y,
+   uint8_t w, uint8_t h, uint16_t outline, uint16_t fill,
+   uint16_t textcolor, char *label, uint8_t textsize);
+  void drawButton(boolean inverted = false);
+  boolean contains(uint16_t x, uint16_t y);
+
+  void press(boolean p);
+  boolean isPressed();
+  boolean justPressed();
+  boolean justReleased();
+
+ private:
+  Adafruit_GFX *_gfx;
+  int16_t _x, _y;
+  uint16_t _w, _h;
+  uint8_t _textsize;
+  uint16_t _outlinecolor, _fillcolor, _textcolor;
+  char _label[10];
+
+  boolean currstate, laststate;
+};
+
+class GFXcanvas1 : public Adafruit_GFX {
+
+ public:
+  GFXcanvas1(uint16_t w, uint16_t h);
+  ~GFXcanvas1(void);
+  void     drawPixel(int16_t x, int16_t y, uint16_t color),
+           fillScreen(uint16_t color);
+  uint8_t *getBuffer(void);
+ private:
+  uint8_t *buffer;
+};
+
+class GFXcanvas16 : public Adafruit_GFX {
+  GFXcanvas16(uint16_t w, uint16_t h);
+  ~GFXcanvas16(void);
+  void      drawPixel(int16_t x, int16_t y, uint16_t color),
+            fillScreen(uint16_t color);
+  uint16_t *getBuffer(void);
+ private:
+  uint16_t *buffer;
+};
+
+#endif // _ADAFRUIT_GFX_H

--- a/Adafruit_GFX.h
+++ b/Adafruit_GFX.h
@@ -66,8 +66,8 @@ class Adafruit_GFX : public Print {
     setRotation(uint8_t r),
     cp437(boolean x=true),
     setFont(const GFXfont *f = NULL),
-    getTextBounds(char *string, int16_t x, int16_t y,
-      int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h),
+    getTextBounds(char *str, int16_t x, int16_t y, int16_t *x1, 
+      int16_t *y1, uint16_t *w, uint16_t *h, uint8_t * glyphWidths = NULL),
     getTextBounds(const __FlashStringHelper *s, int16_t x, int16_t y,
       int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h);
 
@@ -112,7 +112,7 @@ class Adafruit_GFX_Button {
    uint8_t w, uint8_t h, uint16_t outline, uint16_t fill,
    uint16_t textcolor, char *label, uint8_t textsize);
   void drawButton(boolean inverted = false);
-  boolean contains(int16_t x, int16_t y);
+  boolean contains(uint16_t x, uint16_t y);
 
   void press(boolean p);
   boolean isPressed();


### PR DESCRIPTION
Added the feature to clear selective glyphs background, avoiding to clear
the background of the whole text (i.e. with _fillRect_ function).
_fillRect_-ing the whole area behind the text produces a more noticeable blinking than _fillRect_-ing just the glyph which changed.