### PR TITLE
Too early text wrap fix

### DIFF
--- a/Adafruit_GFX.cpp
+++ b/Adafruit_GFX.cpp
@@ -480,7 +480,7 @@ void Adafruit_GFX::write(uint8_t c) {
     } else if(c == '\r') {
       // skip em
     } else {
-      if(wrap && ((cursor_x + textsize * 6) >= _width)) { // Heading off edge?
+      if(wrap && ((cursor_x + textsize * 6) > _width)) { // Heading off edge?
         cursor_x  = 0;            // Reset x to zero
         cursor_y += textsize * 8; // Advance y one line
       }


### PR DESCRIPTION
`cursor_x + textsize * 6` is last pixel to be written, it can be equal `_width`