### PR TITLE
Width and Height of a button should be 16 bit, not 8 bit

### DIFF
--- a/Adafruit_GFX.cpp
+++ b/Adafruit_GFX.cpp
@@ -890,7 +890,7 @@ Adafruit_GFX_Button::Adafruit_GFX_Button(void) {
 }
 
 void Adafruit_GFX_Button::initButton(
- Adafruit_GFX *gfx, int16_t x, int16_t y, uint8_t w, uint8_t h,
+ Adafruit_GFX *gfx, int16_t x, int16_t y, uint16_t w, uint16_t h,
  uint16_t outline, uint16_t fill, uint16_t textcolor,
  char *label, uint8_t textsize)
 {

--- a/Adafruit_GFX.h
+++ b/Adafruit_GFX.h
@@ -109,7 +109,7 @@ class Adafruit_GFX_Button {
  public:
   Adafruit_GFX_Button(void);
   void initButton(Adafruit_GFX *gfx, int16_t x, int16_t y,
-   uint8_t w, uint8_t h, uint16_t outline, uint16_t fill,
+   uint16_t w, uint16_t h, uint16_t outline, uint16_t fill,
    uint16_t textcolor, char *label, uint8_t textsize);
   void drawButton(boolean inverted = false);
   boolean contains(int16_t x, int16_t y);


### PR DESCRIPTION
The display has a height/width of 320 Pixel.
But the button height and width can only be a uint8_t.
Internally the width and height are already 16 bit.

So the init button function should also support 16 bit values