### PR TITLE
Fix matc next simbol position in function write()

### DIFF
--- a/Adafruit_GFX.cpp
+++ b/Adafruit_GFX.cpp
@@ -480,7 +480,7 @@ void Adafruit_GFX::write(uint8_t c) {
     } else if(c == '\r') {
       // skip em
     } else {
-      if(wrap && ((cursor_x + textsize * 6) >= _width)) { // Heading off edge?
+      if(wrap && ((cursor_x + textsize * 6) > _width)) { // Heading off edge?
         cursor_x  = 0;            // Reset x to zero
         cursor_y += textsize * 8; // Advance y one line
       }


### PR DESCRIPTION
Fix matc next simbol position in function write().
Otherwise, the last character is not drawn in a line (for which sufficient space).