### PR TITLE
Add missing const get functions for TextColor, TextSize, and TextWrap.

### DIFF
--- a/Adafruit_GFX.cpp
+++ b/Adafruit_GFX.cpp
@@ -624,8 +624,19 @@ int16_t Adafruit_GFX::getCursorY(void) const {
   return cursor_y;
 }
 
+uint8_t Adafruit_GFX::getTextSize(void) const {
+  return textsize;
+}
+
 void Adafruit_GFX::setTextSize(uint8_t s) {
   textsize = (s > 0) ? s : 1;
+}
+
+int16_t Adafruit_GFX::getTextColor(uint16_t *bg) const {
+  if (bg) {
+    *bg = textbgcolor;
+  }
+  return textcolor;
 }
 
 void Adafruit_GFX::setTextColor(uint16_t c) {
@@ -637,6 +648,10 @@ void Adafruit_GFX::setTextColor(uint16_t c) {
 void Adafruit_GFX::setTextColor(uint16_t c, uint16_t b) {
   textcolor   = c;
   textbgcolor = b;
+}
+
+boolean Adafruit_GFX::getTextWrap(void) const {
+  return wrap;
 }
 
 void Adafruit_GFX::setTextWrap(boolean w) {

--- a/Adafruit_GFX.h
+++ b/Adafruit_GFX.h
@@ -81,6 +81,9 @@ class Adafruit_GFX : public Print {
   int16_t width(void) const;
 
   uint8_t getRotation(void) const;
+  int16_t getTextColor(uint16_t *bg = NULL) const;
+  uint8_t getTextSize(void) const;
+  boolean getTextWrap(void) const;
 
   // get current cursor position (get rotation safe maximum values, using: width() for x, height() for y)
   int16_t getCursorX(void) const;


### PR DESCRIPTION
These tend to be needed in generic code that needs to restore previous state.