### PR TITLE
Set yAdvance to glyph height if face height is zero

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+default.vim
+fontconvert/fontconvert

--- a/fontconvert/fontconvert.c
+++ b/fontconvert/fontconvert.c
@@ -222,8 +222,14 @@ int main(int argc, char *argv[]) {
 	printf("const GFXfont %s PROGMEM = {\n", fontName);
 	printf("  (uint8_t  *)%sBitmaps,\n", fontName);
 	printf("  (GFXglyph *)%sGlyphs,\n", fontName);
-	printf("  0x%02X, 0x%02X, %ld };\n\n",
-	  first, last, face->size->metrics.height >> 6);
+	if (face->size->metrics.height == 0) {
+      // No face height info, assume fixed width and get from a glyph.
+		printf("  0x%02X, 0x%02X, %d };\n\n",
+			first, last, table[0].height);
+	} else {
+		printf("  0x%02X, 0x%02X, %ld };\n\n",
+			first, last, face->size->metrics.height >> 6);
+	}
 	printf("// Approx. %d bytes\n",
 	  bitmapOffset + (last - first + 1) * 7 + 7);
 	// Size estimate is based on AVR struct and pointer sizes;


### PR DESCRIPTION
Bitmapped PCF and BDF font files might not (don't?) have face height information.  If the face height is zero from the face metrics, use the height of a glyph as the yAdvance.  This keeps yAdvance from being zero, which allows line-wrapping to work correctly.

Also added .gitignore.