### PR TITLE
Added String overload to getTextBounds() #90

### DIFF
--- a/Adafruit_GFX.cpp
+++ b/Adafruit_GFX.cpp
@@ -1415,7 +1415,18 @@ void Adafruit_GFX::getTextBounds(const char *str, int16_t x, int16_t y,
     }
 }
 
-// Overload for the same as above, but for String strings
+/**************************************************************************/
+/*!
+    @brief    Helper to determine size of a string with current font/size. Pass string and a cursor position, returns UL corner and W,H.
+    @param    str    The ascii string to measure (as an arduino String() class)
+    @param    x      The current cursor X
+    @param    y      The current cursor Y
+    @param    x1     The boundary X coordinate, set by function
+    @param    y1     The boundary Y coordinate, set by function
+    @param    w      The boundary width, set by function
+    @param    h      The boundary height, set by function
+*/
+/**************************************************************************/
 void Adafruit_GFX::getTextBounds(const String &str, int16_t x, int16_t y,
         int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h) {
     if (str.length() != 0) {

--- a/Adafruit_GFX.cpp
+++ b/Adafruit_GFX.cpp
@@ -1392,7 +1392,7 @@ void Adafruit_GFX::charBounds(char c, int16_t *x, int16_t *y,
     @param    h      The boundary height, set by function
 */
 /**************************************************************************/
-void Adafruit_GFX::getTextBounds(char *str, int16_t x, int16_t y,
+void Adafruit_GFX::getTextBounds(const char *str, int16_t x, int16_t y,
         int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h) {
     uint8_t c; // Current character
 
@@ -1414,6 +1414,15 @@ void Adafruit_GFX::getTextBounds(char *str, int16_t x, int16_t y,
         *h  = maxy - miny + 1;
     }
 }
+
+// Overload for the same as above, but for String strings
+void Adafruit_GFX::getTextBounds(const String &str, int16_t x, int16_t y,
+        int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h) {
+    if (str.length() != 0) {
+        getTextBounds(const_cast<char*>(str.c_str()), x, y, x1, y1, w, h);
+    }
+}
+
 
 /**************************************************************************/
 /*!

--- a/Adafruit_GFX.h
+++ b/Adafruit_GFX.h
@@ -102,10 +102,13 @@ class Adafruit_GFX : public Print {
     setTextWrap(boolean w),
     cp437(boolean x=true),
     setFont(const GFXfont *f = NULL),
-    getTextBounds(char *string, int16_t x, int16_t y,
+    getTextBounds(const char *string, int16_t x, int16_t y,
       int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h),
     getTextBounds(const __FlashStringHelper *s, int16_t x, int16_t y,
+      int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h),
+    getTextBounds(const String &str, int16_t x, int16_t y,
       int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h);
+
 
 #if ARDUINO >= 100
   virtual size_t write(uint8_t);


### PR DESCRIPTION
While it is possible to .print() a String, inability to do .getTextBounds() over String is very inconvenient.
consider this
```
String mytext = "SomeText";
lcd.print(mytext);       // this one works
lcd.getTextBounds(mytext, 0, 0, &x1, &y1, &w1, &h1);    //this one does not
```

So we have to use a temp buffer every time and copy String to char*, like this
```
char char_array[mytext.length() + 1];
mytext.toCharArray(char_array, mytext.length());
lcd.getTextBounds(char_array, 0, 0, &x1, &y1, &w1, &h1);
```

This simple patch adds String overload to getTextBounds() without using a temp buffer. Should  be backward compatible with older code. (addressing Issue #90)