### PR TITLE
Added getXAdvance and getYAdvance methods

### DIFF
--- a/Adafruit_GFX.cpp
+++ b/Adafruit_GFX.cpp
@@ -1043,6 +1043,26 @@ void Adafruit_GFX::getTextBounds(const __FlashStringHelper *str,
     }
 }
 
+// Return the xAdvance value for the passed character in the
+// current font or 0 if the character is not in the current font
+uint8_t Adafruit_GFX::getXAdvance(char c)
+{
+    uint8_t first = pgm_read_byte(&gfxFont->first),
+            last  = pgm_read_byte(&gfxFont->last);
+    if((c >= first) && (c <= last)) { // Char present in this font?
+        GFXglyph *glyph = &(((GFXglyph *)pgm_read_pointer(
+          &gfxFont->glyph))[c - first]);
+        return pgm_read_byte(&glyph->xAdvance);
+	}
+	return 0;
+}
+
+// Return the yAdvance value for the current font
+uint8_t Adafruit_GFX::getYAdvance()
+{
+    return (uint8_t)pgm_read_byte(&gfxFont->yAdvance);
+}
+
 // Return the size of the display (per current rotation)
 int16_t Adafruit_GFX::width(void) const {
     return _width;

--- a/Adafruit_GFX.h
+++ b/Adafruit_GFX.h
@@ -105,6 +105,9 @@ class Adafruit_GFX : public Print {
       int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h),
     getTextBounds(const __FlashStringHelper *s, int16_t x, int16_t y,
       int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h);
+	  
+	uint8_t getXAdvance(char c);
+	uint8_t getYAdvance();
 
 #if ARDUINO >= 100
   virtual size_t write(uint8_t);


### PR DESCRIPTION
I needed to render individual characters to allow me to scroll very long messages on my MAX7219 based display. To do that I needed to get the xAdvance for the character. Here is my PR for that update. I also added a corresponding getYAdvance just in case.