### PR TITLE
Change getTextBounds() from char * to const char * to avoid warnings/errors when passing a const char to it.

### DIFF
--- a/Adafruit_GFX.cpp
+++ b/Adafruit_GFX.cpp
@@ -996,7 +996,7 @@ void Adafruit_GFX::charBounds(char c, int16_t *x, int16_t *y,
 }
 
 // Pass string and a cursor position, returns UL corner and W,H.
-void Adafruit_GFX::getTextBounds(char *str, int16_t x, int16_t y,
+void Adafruit_GFX::getTextBounds(const char *str, int16_t x, int16_t y,
         int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h) {
     uint8_t c; // Current character
 

--- a/Adafruit_GFX.h
+++ b/Adafruit_GFX.h
@@ -101,7 +101,7 @@ class Adafruit_GFX : public Print {
     setTextWrap(boolean w),
     cp437(boolean x=true),
     setFont(const GFXfont *f = NULL),
-    getTextBounds(char *string, int16_t x, int16_t y,
+    getTextBounds(const char *string, int16_t x, int16_t y,
       int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h),
     getTextBounds(const __FlashStringHelper *s, int16_t x, int16_t y,
       int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h);


### PR DESCRIPTION
I like making char * arguments to functions that do not modify the argument const. But if I have a routine that calls getTextBounds() with a const char *, for example:
```
static int
mono_stringwidth(const char *s)
{
        int16_t x, y;
        uint16_t w, h;

        display.getTextBounds(s, 0, 0, &x, &y, &w, &h);
        return (w);
}
```
I get this error:
> invalid conversion from 'const char*' to 'char*' [-fpermissive]

Changing the char * version of getTextBounds() to be const char * solves this issue and works when passing a char * too. Not only will you get an error if you try to modify the const char * by mistake, it can also helps the compiler because it knows this argument cannot be changed.

