### PR TITLE
Fix compile errors USE_FAST_PINIO + compile on Robotis boards

### DIFF
--- a/Adafruit_SPITFT.h
+++ b/Adafruit_SPITFT.h
@@ -16,12 +16,14 @@
 typedef volatile uint8_t RwReg;
 #elif defined(ARDUINO_STM32_FEATHER)
 typedef volatile uint32 RwReg;
+#elif defined(__OPENCR__) || defined (__OPENCM904__)
+#undef USE_FAST_PINIO
 #elif defined(ARDUINO_FEATHER52) || defined(__arm__)
 typedef volatile uint32_t RwReg;
 #elif defined(ESP32) || defined(ESP8266)
 typedef volatile uint32_t RwReg;
 #else
-#undefine USE_FAST_PINIO
+#undef USE_FAST_PINIO
 #endif
 
 #include "Adafruit_SPITFT_Macros.h"

--- a/Adafruit_SPITFT_Macros.h
+++ b/Adafruit_SPITFT_Macros.h
@@ -13,8 +13,8 @@
 #else
 #define SPI_DC_HIGH()           digitalWrite(_dc, HIGH)
 #define SPI_DC_LOW()            digitalWrite(_dc, LOW)
-#define SPI_CS_HIGH()           { if(_cs >= 0) digitalWrite(_cs, HIGH) }
-#define SPI_CS_LOW()            { if(_cs >= 0) digitalWrite(_cs, LOW)  }
+#define SPI_CS_HIGH()           { if(_cs >= 0) digitalWrite(_cs, HIGH); }
+#define SPI_CS_LOW()            { if(_cs >= 0) digitalWrite(_cs, LOW);  }
 #endif
 
 /*


### PR DESCRIPTION
There were a couple of compile issus when you are trying to use a different board which requires you not to use fast pinio.  In particular Robotis OpenCM9.04 as well as the OpenCR 1.0 boards.

They are STM32 based __arm__ boards but do not have the support for setting/clearing IO pins using memory mapped access to one location.

First thing I ran into was the code in the #else casue was using
#undefine
which is not valid, should be #undef

Second issue is once this define was undefined, the #defines for SPI_CS_HIGH
and SPI_CS_LOW did not compile as there was no ; at the end of the digitalWrite.
Probably worked earlier until somone put this statement into a {} pair