### PR TITLE
esp use_fast_pinio undef

### DIFF
--- a/Adafruit_SPITFT.h
+++ b/Adafruit_SPITFT.h
@@ -22,6 +22,7 @@ typedef volatile uint32 RwReg;
 typedef volatile uint32_t RwReg;
 #elif defined(ESP32) || defined(ESP8266)
 typedef volatile uint32_t RwReg;
+#undef USE_FAST_PINIO
 #else
 #undef USE_FAST_PINIO
 #endif


### PR DESCRIPTION
This was never an issue until include macro was moved to below the definition, masked before 1.2.6
via

https://github.com/adafruit/Adafruit-GFX-Library/commit/b2cc77a13b8b35689a99a4c0a7eb9c5d186f8edc#diff-34d217f1a3e35d00f24b2c3a7bca0dad