### PR TITLE
Adafruit_GFX::write implementation should match declaration for older Arduino platform

### DIFF
--- a/Adafruit_GFX.cpp
+++ b/Adafruit_GFX.cpp
@@ -1118,7 +1118,11 @@ void Adafruit_GFX::drawChar(int16_t x, int16_t y, unsigned char c,
     @param  c  The 8-bit ascii character to write
 */
 /**************************************************************************/
+#if ARDUINO >= 100
 size_t Adafruit_GFX::write(uint8_t c) {
+#else
+void Adafruit_GFX::write(uint8_t c) {
+#endif
     if(!gfxFont) { // 'Classic' built-in font
 
         if(c == '\n') {                        // Newline?
@@ -1160,7 +1164,9 @@ size_t Adafruit_GFX::write(uint8_t c) {
         }
 
     }
+#if ARDUINO >= 100
     return 1;
+#endif
 }
 
 /**************************************************************************/


### PR DESCRIPTION
Adafruit_GFX.h has conditional declaration of write method which returns a value only on newer Arduino. 
Change definition of write in Adafruit_GFX.cpp to be void for older platforms.