### PR TITLE
Added a cast to int_16 since height and width are uint_16s.

### DIFF
--- a/Adafruit_GFX.cpp
+++ b/Adafruit_GFX.cpp
@@ -1588,8 +1588,8 @@ void Adafruit_GFX_Button::drawButton(boolean inverted) {
 */
 /**************************************************************************/
 boolean Adafruit_GFX_Button::contains(int16_t x, int16_t y) {
-  return ((x >= _x1) && (x < (_x1 + _w)) &&
-          (y >= _y1) && (y < (_y1 + _h)));
+  return ((x >= _x1) && (x < (int16_t) (_x1 + _w)) &&
+          (y >= _y1) && (y < (int16_t) (_y1 + _h)));
 }
 
 /**************************************************************************/


### PR DESCRIPTION
Note: Consider harmonizing types since uints might spill if someone
invents a 64k wide or high oled.. Jk. Changing h and w might be nice
tho, but keeping changes at minimum here.