### PR TITLE
Add the ability to pass in a SPIClass (Sercom) to use for HW SPI.

### DIFF
--- a/Adafruit_SPITFT.h
+++ b/Adafruit_SPITFT.h
@@ -37,6 +37,7 @@ class Adafruit_SPITFT : public Adafruit_GFX {
     public:
         Adafruit_SPITFT(uint16_t w, uint16_t h, int8_t _CS, int8_t _DC, int8_t _MOSI, int8_t _SCLK, int8_t _RST = -1, int8_t _MISO = -1);
         Adafruit_SPITFT(uint16_t w, uint16_t h, int8_t _CS, int8_t _DC, int8_t _RST = -1);
+        Adafruit_SPITFT(uint16_t w, uint16_t h, int8_t _CS, int8_t _DC, SPIClass *spiClass, int8_t _RST = -1);
 
         virtual void begin(uint32_t freq) = 0;  ///< Virtual begin() function to set SPI frequency, must be overridden in subclass. @param freq Maximum SPI hardware clock speed
 
@@ -98,6 +99,7 @@ class Adafruit_SPITFT : public Adafruit_GFX {
 	  _mosi,                 ///< Arduino pin # for SPI MOSI pin 
 	  _miso;                 ///< Arduino pin # for SPI MISO pin 
 #endif
+        SPIClass *_spiClass;     ///< The SPIClass to use for Hardware SPI
 
 #ifdef USE_FAST_PINIO
         volatile RwReg *mosiport,   ///< Direct chip register for toggling MOSI with fast bitbang IO

--- a/Adafruit_SPITFT_Macros.h
+++ b/Adafruit_SPITFT_Macros.h
@@ -46,27 +46,25 @@
  * Hardware SPI Macros
  * */
 
-#define SPI_OBJECT SPI
-
 #if defined (__AVR__) ||  defined(TEENSYDUINO) ||  defined(ARDUINO_ARCH_STM32F1)
-    #define HSPI_SET_CLOCK() SPI_OBJECT.setClockDivider(SPI_CLOCK_DIV2);
+    #define HSPI_SET_CLOCK() _spiClass->setClockDivider(SPI_CLOCK_DIV2);
 #elif defined (__arm__)
-    #define HSPI_SET_CLOCK() SPI_OBJECT.setClockDivider(11);
+    #define HSPI_SET_CLOCK() _spiClass->setClockDivider(11);
 #elif defined(ESP8266) || defined(ESP32)
-    #define HSPI_SET_CLOCK() SPI_OBJECT.setFrequency(_freq);
+    #define HSPI_SET_CLOCK() _spiClass->setFrequency(_freq);
 #elif defined(RASPI)
-    #define HSPI_SET_CLOCK() SPI_OBJECT.setClock(_freq);
+    #define HSPI_SET_CLOCK() _spiClass->setClock(_freq);
 #elif defined(ARDUINO_ARCH_STM32F1)
-    #define HSPI_SET_CLOCK() SPI_OBJECT.setClock(_freq);
+    #define HSPI_SET_CLOCK() _spiClass->setClock(_freq);
 #else
     #define HSPI_SET_CLOCK()
 #endif
 
 #ifdef SPI_HAS_TRANSACTION
-    #define HSPI_BEGIN_TRANSACTION() SPI_OBJECT.beginTransaction(SPISettings(_freq, MSBFIRST, SPI_MODE0))
-    #define HSPI_END_TRANSACTION()   SPI_OBJECT.endTransaction()
+    #define HSPI_BEGIN_TRANSACTION() _spiClass->beginTransaction(SPISettings(_freq, MSBFIRST, SPI_MODE0))
+    #define HSPI_END_TRANSACTION()   _spiClass->endTransaction()
 #else
-    #define HSPI_BEGIN_TRANSACTION() HSPI_SET_CLOCK(); SPI_OBJECT.setBitOrder(MSBFIRST); SPI_OBJECT.setDataMode(SPI_MODE0)
+    #define HSPI_BEGIN_TRANSACTION() HSPI_SET_CLOCK(); _spiClass->setBitOrder(MSBFIRST); _spiClass->setDataMode(SPI_MODE0)
     #define HSPI_END_TRANSACTION()
 #endif
 
@@ -75,13 +73,13 @@
 #endif
 #if defined(ESP8266) || defined(ESP32)
     // Optimized SPI (ESP8266 and ESP32)
-    #define HSPI_READ()              SPI_OBJECT.transfer(0)
-    #define HSPI_WRITE(b)            SPI_OBJECT.write(b)
-    #define HSPI_WRITE16(s)          SPI_OBJECT.write16(s)
-    #define HSPI_WRITE32(l)          SPI_OBJECT.write32(l)
+    #define HSPI_READ()              _spiClass->transfer(0)
+    #define HSPI_WRITE(b)            _spiClass->write(b)
+    #define HSPI_WRITE16(s)          _spiClass->write16(s)
+    #define HSPI_WRITE32(l)          _spiClass->write32(l)
     #ifdef SPI_HAS_WRITE_PIXELS
         #define SPI_MAX_PIXELS_AT_ONCE  32
-        #define HSPI_WRITE_PIXELS(c,l)   SPI_OBJECT.writePixels(c,l)
+        #define HSPI_WRITE_PIXELS(c,l)   _spiClass->writePixels(c,l)
     #else
         #define HSPI_WRITE_PIXELS(c,l)   for(uint32_t i=0; i<((l)/2); i++){ SPI_WRITE16(((uint16_t*)(c))[i]); }
     #endif
@@ -100,7 +98,7 @@ static inline uint8_t _avr_spi_read(void) {
         #define HSPI_WRITE(b)            {SPDR = (b); while(!(SPSR & _BV(SPIF)));}
         #define HSPI_READ()              _avr_spi_read()
     #else
-        #define HSPI_WRITE(b)            SPI_OBJECT.transfer((uint8_t)(b))
+        #define HSPI_WRITE(b)            _spiClass->transfer((uint8_t)(b))
         #define HSPI_READ()              HSPI_WRITE(0)
     #endif
     #define HSPI_WRITE16(s)          HSPI_WRITE((s) >> 8); HSPI_WRITE(s)
@@ -108,7 +106,7 @@ static inline uint8_t _avr_spi_read(void) {
     #define HSPI_WRITE_PIXELS(c,l)   for(uint32_t i=0; i<(l); i+=2){ HSPI_WRITE(((uint8_t*)(c))[i+1]); HSPI_WRITE(((uint8_t*)(c))[i]); }
 #endif
 
-#define SPI_BEGIN()             if(_sclk < 0){SPI_OBJECT.begin();}
+#define SPI_BEGIN()             if(_sclk < 0){_spiClass->begin();}
 #define SPI_BEGIN_TRANSACTION() if(_sclk < 0){HSPI_BEGIN_TRANSACTION();}
 #define SPI_END_TRANSACTION()   if(_sclk < 0){HSPI_END_TRANSACTION();}
 #define SPI_WRITE16(s)          if(_sclk < 0){HSPI_WRITE16(s);}else{SSPI_WRITE16(s);}


### PR DESCRIPTION
This change allows a SPIClass pointer to be passed in and used as the HW SPI. Allowing a SPIClass to be given opens the door to using SPIs (and associated Sercoms) that are not the default SPI as defined in varaints.cpp. With this change, SPIs that are added in an Arduino sketch and not defined in variant.cpp can be used. It was this change (and associated change in the ST77xx drivers) that allowed me to use the UncannyEyes with the Circuit Playground.