### PR TITLE
Fixed error from fontconvert.c when compiling example sketch of adafruit OLED display

### DIFF
--- a/fontconvert/fontconvert.c
+++ b/fontconvert/fontconvert.c
@@ -16,6 +16,7 @@ Keep 7-bit fonts around as an option in that case, more compact.
 
 See notes at end for glyph nomenclature & other tidbits.
 */
+#ifndef ARDUINO
 
 #include <stdio.h>
 #include <ctype.h>
@@ -282,3 +283,5 @@ the cursor on the X axis after drawing the corresponding symbol.
 There's also some changes with regard to 'background' color and new GFX
 fonts (classic fonts unchanged).  See Adafruit_GFX.cpp for explanation.
 */
+
+#endif /* !ARDUINO */


### PR DESCRIPTION
**Issue:**
When compiling the [example sketch](https://github.com/adafruit/Adafruit_SSD1306/blob/master/examples/ssd1306_128x64_spi/ssd1306_128x64_spi.ino) for adafruit OLED display, the sketch refers to Adafruit_GFX and consequently to fontconvert.c
This file includes a header file named ft2build.h, which many of the compilers fail to find, resulting in compilation error.


Check the discussion on this issue: #88

**Fix:**
Simply adding two lines at the beginning and at the end solves the problem: https://github.com/adafruit/Adafruit-GFX-Library/commit/4a2757c8934461a6936cec47a9c05980031441d8