### PR TITLE
Fix #103 by disabling subpixel rendering.

### DIFF
--- a/fontconvert/fontconvert.c
+++ b/fontconvert/fontconvert.c
@@ -117,6 +117,16 @@ int main(int argc, char *argv[]) {
 		fprintf(stderr, "FreeType init error: %d", err);
 		return err;
 	}
+	
+	// Use TrueType engine version 35, without subpixel rendering.
+	// This improves clarity of fonts since this library does not
+	// support rendering multiple levels of gray in a glyph.
+	// See https://github.com/adafruit/Adafruit-GFX-Library/issues/103
+	FT_UInt interpreter_version = TT_INTERPRETER_VERSION_35;
+	FT_Property_Set( library, "truetype",
+                                  "interpreter-version",
+                                  &interpreter_version );	
+	
 	if((err = FT_New_Face(library, argv[1], 0, &face))) {
 		fprintf(stderr, "Font load error: %d", err);
 		FT_Done_FreeType(library);


### PR DESCRIPTION
Newer versions of FreeType enable subpixel rendering by default. This makes fonts look terrible on displays that don't support it, like the LCDs this library is targeting. This change disables the subpixel rendering and improves the clarity of fonts.

See https://github.com/adafruit/Adafruit-GFX-Library/issues/103#issuecomment-443031001 for more information.