### PR TITLE
Cleanup: Remove `boolean` type usage and bizarre function forward definition.

### DIFF
--- a/Adafruit_GFX.cpp
+++ b/Adafruit_GFX.cpp
@@ -766,7 +766,7 @@ void Adafruit_GFX::drawBitmap(int16_t x, int16_t y,
 
 /**************************************************************************/
 /*!
-   @brief      Draw PROGMEM-resident XBitMap Files (*.xbm), exported from GIMP. 
+   @brief      Draw PROGMEM-resident XBitMap Files (*.xbm), exported from GIMP.
    Usage: Export from GIMP to *.xbm, rename *.xbm to *.c and open in editor.
    C Array can be directly used with this function.
    There is no RAM-resident version of this function; if generating bitmaps
@@ -801,7 +801,7 @@ void Adafruit_GFX::drawXBitmap(int16_t x, int16_t y,
 
 /**************************************************************************/
 /*!
-   @brief   Draw a PROGMEM-resident 8-bit image (grayscale) at the specified (x,y) pos.  
+   @brief   Draw a PROGMEM-resident 8-bit image (grayscale) at the specified (x,y) pos.
    Specifically for 8-bit display devices such as IS31FL3731; no color reduction/expansion is performed.
     @param    x   Top left corner x coordinate
     @param    y   Top left corner y coordinate
@@ -823,7 +823,7 @@ void Adafruit_GFX::drawGrayscaleBitmap(int16_t x, int16_t y,
 
 /**************************************************************************/
 /*!
-   @brief   Draw a RAM-resident 8-bit image (grayscale) at the specified (x,y) pos.  
+   @brief   Draw a RAM-resident 8-bit image (grayscale) at the specified (x,y) pos.
    Specifically for 8-bit display devices such as IS31FL3731; no color reduction/expansion is performed.
     @param    x   Top left corner x coordinate
     @param    y   Top left corner y coordinate
@@ -910,7 +910,7 @@ void Adafruit_GFX::drawGrayscaleBitmap(int16_t x, int16_t y,
 
 /**************************************************************************/
 /*!
-   @brief   Draw a PROGMEM-resident 16-bit image (RGB 5/6/5) at the specified (x,y) position.  
+   @brief   Draw a PROGMEM-resident 16-bit image (RGB 5/6/5) at the specified (x,y) position.
    For 16-bit display devices; no color reduction performed.
     @param    x   Top left corner x coordinate
     @param    y   Top left corner y coordinate
@@ -932,7 +932,7 @@ void Adafruit_GFX::drawRGBBitmap(int16_t x, int16_t y,
 
 /**************************************************************************/
 /*!
-   @brief   Draw a RAM-resident 16-bit image (RGB 5/6/5) at the specified (x,y) position.  
+   @brief   Draw a RAM-resident 16-bit image (RGB 5/6/5) at the specified (x,y) position.
    For 16-bit display devices; no color reduction performed.
     @param    x   Top left corner x coordinate
     @param    y   Top left corner y coordinate
@@ -1245,7 +1245,7 @@ void Adafruit_GFX::setTextColor(uint16_t c, uint16_t b) {
     @param  w Set true for wrapping, false for clipping
 */
 /**************************************************************************/
-void Adafruit_GFX::setTextWrap(boolean w) {
+void Adafruit_GFX::setTextWrap(bool w) {
     wrap = w;
 }
 
@@ -1293,7 +1293,7 @@ void Adafruit_GFX::setRotation(uint8_t x) {
     @param  x  Whether to enable (True) or not (False)
 */
 /**************************************************************************/
-void Adafruit_GFX::cp437(boolean x) {
+void Adafruit_GFX::cp437(bool x) {
     _cp437 = x;
 }
 
@@ -1506,7 +1506,7 @@ int16_t Adafruit_GFX::height(void) const {
     @param   i  True if you want to invert, false to make 'normal'
 */
 /**************************************************************************/
-void Adafruit_GFX::invertDisplay(boolean i) {
+void Adafruit_GFX::invertDisplay(bool i) {
     // Do nothing, must be subclassed if supported by hardware
 }
 
@@ -1585,7 +1585,7 @@ void Adafruit_GFX_Button::initButtonUL(
    @param    inverted Whether to draw with fill/text swapped to indicate 'pressed'
 */
 /**************************************************************************/
-void Adafruit_GFX_Button::drawButton(boolean inverted) {
+void Adafruit_GFX_Button::drawButton(bool inverted) {
   uint16_t fill, outline, text;
 
   if(!inverted) {
@@ -1617,7 +1617,7 @@ void Adafruit_GFX_Button::drawButton(boolean inverted) {
    @returns   True if within button graphics outline
 */
 /**************************************************************************/
-boolean Adafruit_GFX_Button::contains(int16_t x, int16_t y) {
+bool Adafruit_GFX_Button::contains(int16_t x, int16_t y) {
   return ((x >= _x1) && (x < (int16_t) (_x1 + _w)) &&
           (y >= _y1) && (y < (int16_t) (_y1 + _h)));
 }
@@ -1628,7 +1628,7 @@ boolean Adafruit_GFX_Button::contains(int16_t x, int16_t y) {
    @param    p  True for pressed, false for not.
 */
 /**************************************************************************/
-void Adafruit_GFX_Button::press(boolean p) {
+void Adafruit_GFX_Button::press(bool p) {
   laststate = currstate;
   currstate = p;
 }
@@ -1639,7 +1639,7 @@ void Adafruit_GFX_Button::press(boolean p) {
    @returns  True if pressed
 */
 /**************************************************************************/
-boolean Adafruit_GFX_Button::isPressed() { return currstate; }
+bool Adafruit_GFX_Button::isPressed() { return currstate; }
 
 /**************************************************************************/
 /*!
@@ -1647,7 +1647,7 @@ boolean Adafruit_GFX_Button::isPressed() { return currstate; }
    @returns  True if was not-pressed before, now is.
 */
 /**************************************************************************/
-boolean Adafruit_GFX_Button::justPressed() { return (currstate && !laststate); }
+bool Adafruit_GFX_Button::justPressed() { return (currstate && !laststate); }
 
 /**************************************************************************/
 /*!
@@ -1655,7 +1655,7 @@ boolean Adafruit_GFX_Button::justPressed() { return (currstate && !laststate); }
    @returns  True if was pressed before, now is not.
 */
 /**************************************************************************/
-boolean Adafruit_GFX_Button::justReleased() { return (!currstate && laststate); }
+bool Adafruit_GFX_Button::justReleased() { return (!currstate && laststate); }
 
 // -------------------------------------------------------------------------
 

--- a/Adafruit_GFX.h
+++ b/Adafruit_GFX.h
@@ -17,7 +17,7 @@ class Adafruit_GFX : public Print {
   Adafruit_GFX(int16_t w, int16_t h); // Constructor
 
   // This MUST be defined by the subclass:
-  virtual void drawPixel(int16_t x, int16_t y, uint16_t color) = 0;    ///< Virtual drawPixel() function to draw to the screen/framebuffer/etc, must be overridden in subclass. @param x X coordinate.  @param y Y coordinate. @param color 16-bit pixel color. 
+  virtual void drawPixel(int16_t x, int16_t y, uint16_t color) = 0;    ///< Virtual drawPixel() function to draw to the screen/framebuffer/etc, must be overridden in subclass. @param x X coordinate.  @param y Y coordinate. @param color 16-bit pixel color.
 
   // TRANSACTION API / CORE DRAW API
   // These MAY be overridden by the subclass to provide device-specific
@@ -34,7 +34,7 @@ class Adafruit_GFX : public Print {
   // These MAY be overridden by the subclass to provide device-specific
   // optimized code.  Otherwise 'generic' versions are used.
   virtual void setRotation(uint8_t r);
-  virtual void invertDisplay(boolean i);
+  virtual void invertDisplay(bool i);
 
   // BASIC DRAW API
   // These MAY be overridden by the subclass to provide device-specific
@@ -99,8 +99,8 @@ class Adafruit_GFX : public Print {
     setTextColor(uint16_t c),
     setTextColor(uint16_t c, uint16_t bg),
     setTextSize(uint8_t s),
-    setTextWrap(boolean w),
-    cp437(boolean x=true),
+    setTextWrap(bool w),
+    cp437(bool x=true),
     setFont(const GFXfont *f = NULL),
     getTextBounds(const char *string, int16_t x, int16_t y,
       int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h),
@@ -143,7 +143,7 @@ class Adafruit_GFX : public Print {
   uint8_t
     textsize,       ///< Desired magnification of text to print()
     rotation;       ///< Display rotation (0 thru 3)
-  boolean
+  bool
     wrap,           ///< If set, 'wrap' text at right edge of display
     _cp437;         ///< If set, use correct CP437 charset (default is off)
   GFXfont
@@ -164,13 +164,13 @@ class Adafruit_GFX_Button {
   void initButtonUL(Adafruit_GFX *gfx, int16_t x1, int16_t y1,
    uint16_t w, uint16_t h, uint16_t outline, uint16_t fill,
    uint16_t textcolor, char *label, uint8_t textsize);
-  void drawButton(boolean inverted = false);
-  boolean contains(int16_t x, int16_t y);
+  void drawButton(bool inverted = false);
+  bool contains(int16_t x, int16_t y);
 
-  void press(boolean p);
-  boolean isPressed();
-  boolean justPressed();
-  boolean justReleased();
+  void press(bool p);
+  bool isPressed();
+  bool justPressed();
+  bool justReleased();
 
  private:
   Adafruit_GFX *_gfx;
@@ -180,7 +180,7 @@ class Adafruit_GFX_Button {
   uint16_t      _outlinecolor, _fillcolor, _textcolor;
   char          _label[10];
 
-  boolean currstate, laststate;
+  bool currstate, laststate;
 };
 
 

--- a/Adafruit_GFX.h
+++ b/Adafruit_GFX.h
@@ -39,74 +39,73 @@ class Adafruit_GFX : public Print {
   // BASIC DRAW API
   // These MAY be overridden by the subclass to provide device-specific
   // optimized code.  Otherwise 'generic' versions are used.
-  virtual void
-    // It's good to implement those, even if using transaction API
-    drawFastVLine(int16_t x, int16_t y, int16_t h, uint16_t color),
-    drawFastHLine(int16_t x, int16_t y, int16_t w, uint16_t color),
-    fillRect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t color),
-    fillScreen(uint16_t color),
+  // It's good to implement those, even if using transaction API
+  virtual void drawFastVLine(int16_t x, int16_t y, int16_t h, uint16_t color);
+  virtual void drawFastHLine(int16_t x, int16_t y, int16_t w, uint16_t color);
+  virtual void fillRect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t color);
+  virtual void fillScreen(uint16_t color);
     // Optional and probably not necessary to change
-    drawLine(int16_t x0, int16_t y0, int16_t x1, int16_t y1, uint16_t color),
-    drawRect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t color);
+  virtual void drawLine(int16_t x0, int16_t y0, int16_t x1, int16_t y1, uint16_t color);
+  virtual void drawRect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t color);
 
   // These exist only with Adafruit_GFX (no subclass overrides)
-  void
-    drawCircle(int16_t x0, int16_t y0, int16_t r, uint16_t color),
-    drawCircleHelper(int16_t x0, int16_t y0, int16_t r, uint8_t cornername,
-      uint16_t color),
-    fillCircle(int16_t x0, int16_t y0, int16_t r, uint16_t color),
-    fillCircleHelper(int16_t x0, int16_t y0, int16_t r, uint8_t cornername,
-      int16_t delta, uint16_t color),
-    drawTriangle(int16_t x0, int16_t y0, int16_t x1, int16_t y1,
-      int16_t x2, int16_t y2, uint16_t color),
-    fillTriangle(int16_t x0, int16_t y0, int16_t x1, int16_t y1,
-      int16_t x2, int16_t y2, uint16_t color),
-    drawRoundRect(int16_t x0, int16_t y0, int16_t w, int16_t h,
-      int16_t radius, uint16_t color),
-    fillRoundRect(int16_t x0, int16_t y0, int16_t w, int16_t h,
-      int16_t radius, uint16_t color),
-    drawBitmap(int16_t x, int16_t y, const uint8_t bitmap[],
-      int16_t w, int16_t h, uint16_t color),
-    drawBitmap(int16_t x, int16_t y, const uint8_t bitmap[],
-      int16_t w, int16_t h, uint16_t color, uint16_t bg),
-    drawBitmap(int16_t x, int16_t y, uint8_t *bitmap,
-      int16_t w, int16_t h, uint16_t color),
-    drawBitmap(int16_t x, int16_t y, uint8_t *bitmap,
-      int16_t w, int16_t h, uint16_t color, uint16_t bg),
-    drawXBitmap(int16_t x, int16_t y, const uint8_t bitmap[],
-      int16_t w, int16_t h, uint16_t color),
-    drawGrayscaleBitmap(int16_t x, int16_t y, const uint8_t bitmap[],
-      int16_t w, int16_t h),
-    drawGrayscaleBitmap(int16_t x, int16_t y, uint8_t *bitmap,
-      int16_t w, int16_t h),
-    drawGrayscaleBitmap(int16_t x, int16_t y,
+
+  void drawCircle(int16_t x0, int16_t y0, int16_t r, uint16_t color);
+  void drawCircleHelper(int16_t x0, int16_t y0, int16_t r, uint8_t cornername,
+      uint16_t color);
+  void fillCircle(int16_t x0, int16_t y0, int16_t r, uint16_t color);
+  void fillCircleHelper(int16_t x0, int16_t y0, int16_t r, uint8_t cornername,
+      int16_t delta, uint16_t color);
+  void drawTriangle(int16_t x0, int16_t y0, int16_t x1, int16_t y1,
+      int16_t x2, int16_t y2, uint16_t color);
+  void fillTriangle(int16_t x0, int16_t y0, int16_t x1, int16_t y1,
+      int16_t x2, int16_t y2, uint16_t color);
+  void drawRoundRect(int16_t x0, int16_t y0, int16_t w, int16_t h,
+      int16_t radius, uint16_t color);
+  void fillRoundRect(int16_t x0, int16_t y0, int16_t w, int16_t h,
+      int16_t radius, uint16_t color);
+  void drawBitmap(int16_t x, int16_t y, const uint8_t bitmap[],
+      int16_t w, int16_t h, uint16_t color);
+  void drawBitmap(int16_t x, int16_t y, const uint8_t bitmap[],
+      int16_t w, int16_t h, uint16_t color, uint16_t bg);
+  void drawBitmap(int16_t x, int16_t y, uint8_t *bitmap,
+      int16_t w, int16_t h, uint16_t color);
+  void drawBitmap(int16_t x, int16_t y, uint8_t *bitmap,
+      int16_t w, int16_t h, uint16_t color, uint16_t bg);
+  void drawXBitmap(int16_t x, int16_t y, const uint8_t bitmap[],
+      int16_t w, int16_t h, uint16_t color);
+  void drawGrayscaleBitmap(int16_t x, int16_t y, const uint8_t bitmap[],
+      int16_t w, int16_t h);
+  void drawGrayscaleBitmap(int16_t x, int16_t y, uint8_t *bitmap,
+      int16_t w, int16_t h);
+  void drawGrayscaleBitmap(int16_t x, int16_t y,
       const uint8_t bitmap[], const uint8_t mask[],
-      int16_t w, int16_t h),
-    drawGrayscaleBitmap(int16_t x, int16_t y,
-      uint8_t *bitmap, uint8_t *mask, int16_t w, int16_t h),
-    drawRGBBitmap(int16_t x, int16_t y, const uint16_t bitmap[],
-      int16_t w, int16_t h),
-    drawRGBBitmap(int16_t x, int16_t y, uint16_t *bitmap,
-      int16_t w, int16_t h),
-    drawRGBBitmap(int16_t x, int16_t y,
+      int16_t w, int16_t h);
+  void drawGrayscaleBitmap(int16_t x, int16_t y,
+      uint8_t *bitmap, uint8_t *mask, int16_t w, int16_t h);
+  void drawRGBBitmap(int16_t x, int16_t y, const uint16_t bitmap[],
+      int16_t w, int16_t h);
+  void drawRGBBitmap(int16_t x, int16_t y, uint16_t *bitmap,
+      int16_t w, int16_t h);
+  void drawRGBBitmap(int16_t x, int16_t y,
       const uint16_t bitmap[], const uint8_t mask[],
-      int16_t w, int16_t h),
-    drawRGBBitmap(int16_t x, int16_t y,
-      uint16_t *bitmap, uint8_t *mask, int16_t w, int16_t h),
-    drawChar(int16_t x, int16_t y, unsigned char c, uint16_t color,
-      uint16_t bg, uint8_t size),
-    setCursor(int16_t x, int16_t y),
-    setTextColor(uint16_t c),
-    setTextColor(uint16_t c, uint16_t bg),
-    setTextSize(uint8_t s),
-    setTextWrap(bool w),
-    cp437(bool x=true),
-    setFont(const GFXfont *f = NULL),
-    getTextBounds(const char *string, int16_t x, int16_t y,
-      int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h),
-    getTextBounds(const __FlashStringHelper *s, int16_t x, int16_t y,
-      int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h),
-    getTextBounds(const String &str, int16_t x, int16_t y,
+      int16_t w, int16_t h);
+  void drawRGBBitmap(int16_t x, int16_t y,
+      uint16_t *bitmap, uint8_t *mask, int16_t w, int16_t h);
+  void drawChar(int16_t x, int16_t y, unsigned char c, uint16_t color,
+      uint16_t bg, uint8_t size);
+  void setCursor(int16_t x, int16_t y);
+  void setTextColor(uint16_t c);
+  void setTextColor(uint16_t c, uint16_t bg);
+  void setTextSize(uint8_t s);
+  void setTextWrap(bool w);
+  void cp437(bool x=true);
+  void setFont(const GFXfont *f = NULL);
+  void getTextBounds(const char *string, int16_t x, int16_t y,
+      int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h);
+  void getTextBounds(const __FlashStringHelper *s, int16_t x, int16_t y,
+      int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h);
+  void getTextBounds(const String &str, int16_t x, int16_t y,
       int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h);
 
 
@@ -126,28 +125,28 @@ class Adafruit_GFX : public Print {
   int16_t getCursorY(void) const;
 
  protected:
-  void
-    charBounds(char c, int16_t *x, int16_t *y,
-      int16_t *minx, int16_t *miny, int16_t *maxx, int16_t *maxy);
-  const int16_t
-    WIDTH,          ///< This is the 'raw' display width - never changes
-    HEIGHT;         ///< This is the 'raw' display height - never changes
-  int16_t
-    _width,         ///< Display width as modified by current rotation
-    _height,        ///< Display height as modified by current rotation
-    cursor_x,       ///< x location to start print()ing text
-    cursor_y;       ///< y location to start print()ing text
-  uint16_t
-    textcolor,      ///< 16-bit background color for print()
-    textbgcolor;    ///< 16-bit text color for print()
-  uint8_t
-    textsize,       ///< Desired magnification of text to print()
-    rotation;       ///< Display rotation (0 thru 3)
-  bool
-    wrap,           ///< If set, 'wrap' text at right edge of display
-    _cp437;         ///< If set, use correct CP437 charset (default is off)
-  GFXfont
-    *gfxFont;       ///< Pointer to special font
+  void charBounds(char c, int16_t *x, int16_t *y,
+          int16_t *minx, int16_t *miny, int16_t *maxx, int16_t *maxy);
+
+  const int16_t WIDTH;          ///< This is the 'raw' display width - never changes
+  const int16_t HEIGHT;         ///< This is the 'raw' display height - never changes
+
+  int16_t _width;         ///< Display width as modified by current rotation
+  int16_t _height;        ///< Display height as modified by current rotation
+  int16_t cursor_x;       ///< x location to start print()ing text
+  int16_t cursor_y;       ///< y location to start print()ing text
+
+
+  uint16_t textcolor;      ///< 16-bit background color for print()
+  uint16_t textbgcolor;    ///< 16-bit text color for print()
+
+  uint8_t textsize;       ///< Desired magnification of text to print()
+  uint8_t rotation;       ///< Display rotation (0 thru 3)
+
+  bool wrap;           ///< If set, 'wrap' text at right edge of display
+  bool _cp437;         ///< If set, use correct CP437 charset (default is off)
+
+  GFXfont *gfxFont;       ///< Pointer to special font
 };
 
 
@@ -189,8 +188,8 @@ class GFXcanvas1 : public Adafruit_GFX {
  public:
   GFXcanvas1(uint16_t w, uint16_t h);
   ~GFXcanvas1(void);
-  void     drawPixel(int16_t x, int16_t y, uint16_t color),
-           fillScreen(uint16_t color);
+  void drawPixel(int16_t x, int16_t y, uint16_t color);
+  void fillScreen(uint16_t color);
   uint8_t *getBuffer(void);
  private:
   uint8_t *buffer;
@@ -202,9 +201,9 @@ class GFXcanvas8 : public Adafruit_GFX {
  public:
   GFXcanvas8(uint16_t w, uint16_t h);
   ~GFXcanvas8(void);
-  void     drawPixel(int16_t x, int16_t y, uint16_t color),
-           fillScreen(uint16_t color),
-           writeFastHLine(int16_t x, int16_t y, int16_t w, uint16_t color);
+  void drawPixel(int16_t x, int16_t y, uint16_t color);
+  void fillScreen(uint16_t color);
+  void writeFastHLine(int16_t x, int16_t y, int16_t w, uint16_t color);
 
   uint8_t *getBuffer(void);
  private:
@@ -217,8 +216,8 @@ class GFXcanvas16 : public Adafruit_GFX {
  public:
   GFXcanvas16(uint16_t w, uint16_t h);
   ~GFXcanvas16(void);
-  void      drawPixel(int16_t x, int16_t y, uint16_t color),
-            fillScreen(uint16_t color);
+  void drawPixel(int16_t x, int16_t y, uint16_t color);
+  void fillScreen(uint16_t color);
   uint16_t *getBuffer(void);
  private:
   uint16_t *buffer;

--- a/Adafruit_SPITFT.cpp
+++ b/Adafruit_SPITFT.cpp
@@ -57,7 +57,7 @@
 #include <malloc.h> // memalign() function
 
 // DMA transfer-in-progress indicator and callback
-static volatile boolean dma_busy = false;
+static volatile bool dma_busy = false;
 static void dma_callback(Adafruit_ZeroDMA *dma) {
     dma_busy = false;
 }
@@ -94,7 +94,7 @@ uint16_t Adafruit_SPITFT::color565(uint8_t red, uint8_t green, uint8_t blue) {
 /**************************************************************************/
 Adafruit_SPITFT::Adafruit_SPITFT(uint16_t w, uint16_t h,
 				 int8_t cs, int8_t dc, int8_t mosi,
-				 int8_t sclk, int8_t rst, int8_t miso) 
+				 int8_t sclk, int8_t rst, int8_t miso)
   : Adafruit_GFX(w, h) {
     _cs   = cs;
     _dc   = dc;
@@ -142,8 +142,8 @@ Adafruit_SPITFT::Adafruit_SPITFT(uint16_t w, uint16_t h,
 */
 /**************************************************************************/
 Adafruit_SPITFT::Adafruit_SPITFT(uint16_t w, uint16_t h,
-				 int8_t cs, int8_t dc, int8_t rst) 
-  : Adafruit_SPITFT(w, h, &SPI, cs, dc, rst) 
+				 int8_t cs, int8_t dc, int8_t rst)
+  : Adafruit_SPITFT(w, h, &SPI, cs, dc, rst)
 {
   // We just call the hardware SPI instantiator with the default SPI device (&SPI)
 }
@@ -160,7 +160,7 @@ Adafruit_SPITFT::Adafruit_SPITFT(uint16_t w, uint16_t h,
 */
 /**************************************************************************/
 Adafruit_SPITFT::Adafruit_SPITFT(uint16_t w, uint16_t h, SPIClass *spiClass,
-				 int8_t cs, int8_t dc, int8_t rst) 
+				 int8_t cs, int8_t dc, int8_t rst)
   : Adafruit_GFX(w, h) {
     _cs   = cs;
     _dc   = dc;
@@ -768,7 +768,7 @@ void Adafruit_SPITFT::fillRect(int16_t x, int16_t y, int16_t w, int16_t h,
     @param   i  True if you want to invert, false to make 'normal'
 */
 /**************************************************************************/
-void Adafruit_SPITFT::invertDisplay(boolean i) {
+void Adafruit_SPITFT::invertDisplay(bool i) {
   startWrite();
   writeCommand(i ? invertOnCommand : invertOffCommand);
   endWrite();
@@ -777,9 +777,9 @@ void Adafruit_SPITFT::invertDisplay(boolean i) {
 
 /**************************************************************************/
 /*!
-   @brief   Draw a 16-bit image (RGB 5/6/5) at the specified (x,y) position.  
+   @brief   Draw a 16-bit image (RGB 5/6/5) at the specified (x,y) position.
    For 16-bit display devices; no color reduction performed.
-   Adapted from https://github.com/PaulStoffregen/ILI9341_t3 
+   Adapted from https://github.com/PaulStoffregen/ILI9341_t3
    by Marc MERLIN. See examples/pictureEmbed to use this.
    5/6/2017: function name and arguments have changed for compatibility
    with current GFX library and to avoid naming problems in prior

--- a/Adafruit_SPITFT.h
+++ b/Adafruit_SPITFT.h
@@ -97,7 +97,7 @@ class Adafruit_SPITFT : public Adafruit_GFX {
         using     Adafruit_GFX::drawRGBBitmap; // Check base class first
         void      drawRGBBitmap(int16_t x, int16_t y,
                     uint16_t *pcolors, int16_t w, int16_t h);
-	void      invertDisplay(boolean i);
+	void      invertDisplay(bool i);
 
         uint16_t  color565(uint8_t r, uint8_t g, uint8_t b);
         void      writeCommand(uint8_t cmd);
@@ -109,13 +109,13 @@ class Adafruit_SPITFT : public Adafruit_GFX {
         uint32_t _freq;         ///< SPI clock frequency (for hardware SPI)
 #if defined (__AVR__) || defined(TEENSYDUINO) || defined (ESP8266) || defined (ESP32)
         int8_t  _cs, _dc, _rst, _sclk, _mosi, _miso;
-#else 
-        int32_t  _cs,            ///< Arduino pin # for chip-select pin 
-	  _dc,                   ///< Arduino pin # for data-command pin 
-	  _rst,                  ///< Arduino pin # for reset pin 
-	  _sclk,                 ///< Arduino pin # for SPI clock pin 
-	  _mosi,                 ///< Arduino pin # for SPI MOSI pin 
-	  _miso;                 ///< Arduino pin # for SPI MISO pin 
+#else
+        int32_t  _cs,            ///< Arduino pin # for chip-select pin
+	  _dc,                   ///< Arduino pin # for data-command pin
+	  _rst,                  ///< Arduino pin # for reset pin
+	  _sclk,                 ///< Arduino pin # for SPI clock pin
+	  _mosi,                 ///< Arduino pin # for SPI MOSI pin
+	  _miso;                 ///< Arduino pin # for SPI MISO pin
 #endif
 
 #ifdef USE_FAST_PINIO
@@ -124,11 +124,11 @@ class Adafruit_SPITFT : public Adafruit_GFX {
 	  *clkport,             ///< Direct chip register for toggling CLK with fast bitbang IO
 	  *dcport,              ///< Direct chip register for toggling DC with fast bitbang IO
 	  *csport;              ///< Direct chip register for toggling CS with fast bitbang IO
-        RwReg  mosipinmask,     ///< bitmask for turning on/off MOSI with fast register bitbang IO 
-	  misopinmask,          ///< bitmask for turning on/off MISO with fast register bitbang IO 
-	  clkpinmask,           ///< bitmask for turning on/off CLK with fast register bitbang IO 
-	  cspinmask,            ///< bitmask for turning on/off CS with fast register bitbang IO 
-	  dcpinmask;            ///< bitmask for turning on/off DC with fast register bitbang IO 
+        RwReg  mosipinmask,     ///< bitmask for turning on/off MOSI with fast register bitbang IO
+	  misopinmask,          ///< bitmask for turning on/off MISO with fast register bitbang IO
+	  clkpinmask,           ///< bitmask for turning on/off CLK with fast register bitbang IO
+	  cspinmask,            ///< bitmask for turning on/off CS with fast register bitbang IO
+	  dcpinmask;            ///< bitmask for turning on/off DC with fast register bitbang IO
 #endif
 
 	uint8_t   invertOnCommand = 0,    ///<  SPI command byte to turn on invert

--- a/gfxfont.h
+++ b/gfxfont.h
@@ -9,21 +9,21 @@
 
 /// Font data stored PER GLYPH
 typedef struct {
-	uint16_t bitmapOffset;     ///< Pointer into GFXfont->bitmap
-	uint8_t  width;            ///< Bitmap dimensions in pixels
-        uint8_t  height;           ///< Bitmap dimensions in pixels
-	uint8_t  xAdvance;         ///< Distance to advance cursor (x axis)
-	int8_t   xOffset;          ///< X dist from cursor pos to UL corner
-        int8_t   yOffset;          ///< Y dist from cursor pos to UL corner
+    uint16_t bitmapOffset;     ///< Pointer into GFXfont->bitmap
+    uint8_t  width;            ///< Bitmap dimensions in pixels
+    uint8_t  height;           ///< Bitmap dimensions in pixels
+    uint8_t  xAdvance;         ///< Distance to advance cursor (x axis)
+    int8_t   xOffset;          ///< X dist from cursor pos to UL corner
+    int8_t   yOffset;          ///< Y dist from cursor pos to UL corner
 } GFXglyph;
 
 /// Data stored for FONT AS A WHOLE
-typedef struct { 
-	uint8_t  *bitmap;      ///< Glyph bitmaps, concatenated
-	GFXglyph *glyph;       ///< Glyph array
-	uint8_t   first;       ///< ASCII extents (first char)
-        uint8_t   last;        ///< ASCII extents (last char)
-	uint8_t   yAdvance;    ///< Newline distance (y axis)
+typedef struct {
+    uint8_t  *bitmap;      ///< Glyph bitmaps, concatenated
+    GFXglyph *glyph;       ///< Glyph array
+    uint8_t   first;       ///< ASCII extents (first char)
+    uint8_t   last;        ///< ASCII extents (last char)
+    uint8_t   yAdvance;    ///< Newline distance (y axis)
 } GFXfont;
 
 #endif // _GFXFONT_H_


### PR DESCRIPTION
Currently, this library uses the arduino `boolean` type, which was (and is) basically a really terrible idea that shouldn't have ever happened (how was that ever a thing?). The PR gets rid of it, because c++ has a native `bool` type.

Also, the function definitions in the header were just, well, *weird*, using one return type for a giant list of functions. This PR also cleans that up, so that you have properly independent definitions for each function. 