### PR TITLE
Include FT_TRUETYPE_DRIVER_H in fontconvert.c

### DIFF
--- a/fontconvert/fontconvert.c
+++ b/fontconvert/fontconvert.c
@@ -23,6 +23,7 @@ See notes at end for glyph nomenclature & other tidbits.
 #include <stdint.h>
 #include <ft2build.h>
 #include FT_GLYPH_H
+#include FT_TRUETYPE_DRIVER_H
 #include "../gfxfont.h" // Adafruit_GFX font structures
 
 #define DPI 141 // Approximate res. of Adafruit 2.8" TFT


### PR DESCRIPTION
To fix error about `TT_INTERPRETER_VERSION_35` being undefined on some FreeType versions.

Fixes #193