### PR TITLE
added function scrollUp() to scroll display with println()

### DIFF
--- a/Adafruit_GFX.cpp
+++ b/Adafruit_GFX.cpp
@@ -221,10 +221,18 @@ void Adafruit_GFX::endWrite() {
 
 /**************************************************************************/
 /*!
-   @brief    Scroll the display up one textsize line
+   @brief    Scroll the display up one textsize line; virtual to be implemented in driver
 */
 /**************************************************************************/
 void Adafruit_GFX::scrollUp() {
+}
+
+/**************************************************************************/
+/*!
+   @brief    update display; virtual to be implemented in driver
+*/
+/**************************************************************************/
+void Adafruit_GFX::display() {
 }
 
 /**************************************************************************/

--- a/Adafruit_GFX.cpp
+++ b/Adafruit_GFX.cpp
@@ -1134,12 +1134,14 @@ size_t Adafruit_GFX::write(uint8_t c) {
         if(c == '\n') {                        // Newline?
             cursor_x  = 0;                     // Reset x to zero,
             cursor_y += textsize * 8;          // advance y one line
+						display(); 												 // display after a line feed
         } else if(c != '\r') {                 // Ignore carriage returns
             if(wrap && ((cursor_x + textsize * 6) > _width)) { // Off right?
                 cursor_x  = 0;                 // Reset x to zero,
                 cursor_y += textsize * 8;      // advance y one line
             }
-            drawChar(cursor_x, cursor_y, c, textcolor, textbgcolor, textsize);
+	        if (cursor_y > HEIGHT) scrollUp();   // scroll up one line automatically BEFORE printing the new line
+					drawChar(cursor_x, cursor_y, c, textcolor, textbgcolor, textsize);
             cursor_x += textsize * 6;          // Advance x one char
         }
 
@@ -1150,6 +1152,7 @@ size_t Adafruit_GFX::write(uint8_t c) {
             cursor_y += (int16_t)textsize *
                         (uint8_t)pgm_read_byte(&gfxFont->yAdvance);
         } else if(c != '\r') {
+	        //if (cursor_y > HEIGHT) scrollUp();  // scroll up one line automatically -- NOT YET SUPPORTED with custom font
             uint8_t first = pgm_read_byte(&gfxFont->first);
             if((c >= first) && (c <= (uint8_t)pgm_read_byte(&gfxFont->last))) {
                 GFXglyph *glyph = &(((GFXglyph *)pgm_read_pointer(

--- a/Adafruit_GFX.cpp
+++ b/Adafruit_GFX.cpp
@@ -216,7 +216,15 @@ void Adafruit_GFX::writeFillRect(int16_t x, int16_t y, int16_t w, int16_t h,
    @brief    End a display-writing routine, overwrite in subclasses if startWrite is defined!
 */
 /**************************************************************************/
-void Adafruit_GFX::endWrite(){
+void Adafruit_GFX::endWrite() {
+}
+
+/**************************************************************************/
+/*!
+   @brief    Scroll the display up one textsize line
+*/
+/**************************************************************************/
+void Adafruit_GFX::scrollUp() {
 }
 
 /**************************************************************************/

--- a/Adafruit_GFX.h
+++ b/Adafruit_GFX.h
@@ -18,6 +18,11 @@ class Adafruit_GFX : public Print {
 
   // This MUST be defined by the subclass:
   virtual void drawPixel(int16_t x, int16_t y, uint16_t color) = 0;    ///< Virtual drawPixel() function to draw to the screen/framebuffer/etc, must be overridden in subclass. @param x X coordinate.  @param y Y coordinate. @param color 16-bit pixel color. 
+  // adding function to scroll display up a line for use with println must be overriden at device driver level as is drawPixel
+	// also add virtual function to display buffer on device as I want to do display println automatically after a scrollUp which needs to be called inside the library
+  virtual void scrollUp(void) = 0; 		// scroll display up one line of text
+	virtual void display(void) = 0; 		// display device buffer
+
 
   // TRANSACTION API / CORE DRAW API
   // These MAY be overridden by the subclass to provide device-specific

--- a/Adafruit_GFX.h
+++ b/Adafruit_GFX.h
@@ -34,7 +34,7 @@ class Adafruit_GFX : public Print {
 	// adding function to scroll display up a line for use with println must be overriden at device driver level as is drawPixel
 	// also add virtual function to display buffer on device as I want to do display println automatically after a scrollUp which needs to be called inside the library
   virtual void scrollUp(void); 				// scroll display up one line of text
-	virtual void display(void) = 0;  		// display device buffer
+  virtual void display(void);  				// display device buffer
 
   // CONTROL API
   // These MAY be overridden by the subclass to provide device-specific

--- a/Adafruit_GFX.h
+++ b/Adafruit_GFX.h
@@ -18,10 +18,6 @@ class Adafruit_GFX : public Print {
 
   // This MUST be defined by the subclass:
   virtual void drawPixel(int16_t x, int16_t y, uint16_t color) = 0;    ///< Virtual drawPixel() function to draw to the screen/framebuffer/etc, must be overridden in subclass. @param x X coordinate.  @param y Y coordinate. @param color 16-bit pixel color. 
-  // adding function to scroll display up a line for use with println must be overriden at device driver level as is drawPixel
-	// also add virtual function to display buffer on device as I want to do display println automatically after a scrollUp which needs to be called inside the library
-  virtual void scrollUp(void) = 0; 		// scroll display up one line of text
-	virtual void display(void) = 0; 		// display device buffer
 
 
   // TRANSACTION API / CORE DRAW API
@@ -34,6 +30,11 @@ class Adafruit_GFX : public Print {
   virtual void writeFastHLine(int16_t x, int16_t y, int16_t w, uint16_t color);
   virtual void writeLine(int16_t x0, int16_t y0, int16_t x1, int16_t y1, uint16_t color);
   virtual void endWrite(void);
+
+	// adding function to scroll display up a line for use with println must be overriden at device driver level as is drawPixel
+	// also add virtual function to display buffer on device as I want to do display println automatically after a scrollUp which needs to be called inside the library
+  virtual void scrollUp(void); 				// scroll display up one line of text
+	virtual void display(void) = 0;  		// display device buffer
 
   // CONTROL API
   // These MAY be overridden by the subclass to provide device-specific


### PR DESCRIPTION
This is my second pull request to a public project, so hopefully it's fine, otherwise let me know so I can improve. I tried implementing this keeping in mind other products but I am not sure this will be okay. By all means, have a more experienced person change what is required.

This was developed on a Adafruit Huzzah32 Feather stack with an OLED 128x32 Wing using the Adafruit Arduino support libraries on Win10x64 MS Visual Studio 2017 Community Edition with VisualGDB extensions supporting my Segger J-Link for JTAG debugging.

This function is called from Adafruit_GFX (pull coming soon)::write() to scroll the display if cursorY is greater than the display height. It will also call the driver display() function. This function is to allow the print system to display as many other terminals do. Printing without \n will work as expected. I can see adding a flag to toggle this behavior.

- only supporting standard font for ssd1306 OLED 128x32 as that is all I have to test on

Thanks Adafruit for the openness of your systems !

Attached is an Arduino test sketch. Please remember you need my fork of Adafruit_SSD1306 for it to work fully otherwise, with the empty function nothing much will happen:
[scroll-print.zip](https://github.com/adafruit/Adafruit_SSD1306/files/2752608/scroll-print.zip)
