### PR TITLE
Add capability for using extended character sets

### DIFF
--- a/Adafruit_GFX.h
+++ b/Adafruit_GFX.h
@@ -109,6 +109,8 @@ class Adafruit_GFX : public Print {
     getTextBounds(const String &str, int16_t x, int16_t y,
       int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h);
 
+  // Serial UTF-8 decoder
+  uint16_t decodeUTF8(uint8_t c);
 
 #if ARDUINO >= 100
   virtual size_t write(uint8_t);
@@ -148,6 +150,9 @@ class Adafruit_GFX : public Print {
     _cp437;         ///< If set, use correct CP437 charset (default is off)
   GFXfont
     *gfxFont;       ///< Pointer to special font
+
+  uint8_t  decoderState = 0;   // UTF-8 decoder state
+  uint16_t decoderBuffer;      // Unicode code-point buffer
 };
 
 

--- a/gfxfont.h
+++ b/gfxfont.h
@@ -21,8 +21,8 @@ typedef struct {
 typedef struct { 
 	uint8_t  *bitmap;      ///< Glyph bitmaps, concatenated
 	GFXglyph *glyph;       ///< Glyph array
-	uint8_t   first;       ///< ASCII extents (first char)
-        uint8_t   last;        ///< ASCII extents (last char)
+	uint16_t   first;       ///< ASCII extents (first char)
+        uint16_t   last;        ///< ASCII extents (last char)
 	uint8_t   yAdvance;    ///< Newline distance (y axis)
 } GFXfont;
 


### PR DESCRIPTION
UTF-8 decoder added to print stream so the UTF-8 encoded Unicode strings produced by the compiler are rendered correctly on the graphical displays.

Example for ILI9341 TFT showing printing Hiragana characters to screen here:

[hiragana_example.zip](https://github.com/adafruit/Adafruit-GFX-Library/files/2848193/hiragana_example.zip)

This update makes glyphs from the entire 16 bit Unicode Basic Multilingual Plane available. See comments in the example. This example uses ~45% of FLASH on an UNO so it should run fine on any hardware. The included font files were generated by fontconvert tool with the Unicode Hiragana code point range of 12353 - 12435.
