### PR TITLE
Add capability to use custom fonts that include characters from the Unicode Basic Multilingual Plane

### DIFF
--- a/Adafruit_GFX.cpp
+++ b/Adafruit_GFX.cpp
@@ -1018,13 +1018,13 @@ void Adafruit_GFX::drawRGBBitmap(int16_t x, int16_t y,
    @brief   Draw a single character
     @param    x   Bottom left corner x coordinate
     @param    y   Bottom left corner y coordinate
-    @param    c   The 8-bit font-indexed character (likely ascii)
+    @param    c   The 16-bit font-indexed character
     @param    color 16-bit 5-6-5 Color to draw chraracter with
     @param    bg 16-bit 5-6-5 Color to fill background with (if same as color, no background)
     @param    size  Font magnification level, 1 is 'original' size
 */
 /**************************************************************************/
-void Adafruit_GFX::drawChar(int16_t x, int16_t y, unsigned char c,
+void Adafruit_GFX::drawChar(int16_t x, int16_t y, uint16_t c,
   uint16_t color, uint16_t bg, uint8_t size) {
 
     if(!gfxFont) { // 'Classic' built-in font
@@ -1066,7 +1066,7 @@ void Adafruit_GFX::drawChar(int16_t x, int16_t y, unsigned char c,
         // newlines, returns, non-printable characters, etc.  Calling
         // drawChar() directly with 'bad' characters of font may cause mayhem!
 
-        c -= (uint8_t)pgm_read_byte(&gfxFont->first);
+        c -= pgm_read_word(&gfxFont->first);
         GFXglyph *glyph  = &(((GFXglyph *)pgm_read_pointer(&gfxFont->glyph))[c]);
         uint8_t  *bitmap = (uint8_t *)pgm_read_pointer(&gfxFont->bitmap);
 
@@ -1185,12 +1185,12 @@ uint16_t Adafruit_GFX::decodeUTF8(uint8_t c)
 /**************************************************************************/
 /*!
     @brief  Print one byte/character of data, used to support print()
-    @param  c  The 8-bit ascii character to write
+    @param  utf8  The 8-bit UTF-8 or ASCII code
 */
 /**************************************************************************/
-size_t Adafruit_GFX::write(uint8_t c) {
+size_t Adafruit_GFX::write(uint8_t utf8) {
   
-    c = (uint8_t)decodeUTF8(c);
+    uint16_t c = decodeUTF8(utf8);
     
     if ( c==0 ) return 1;
 
@@ -1215,8 +1215,8 @@ size_t Adafruit_GFX::write(uint8_t c) {
             cursor_y += (int16_t)textsize *
                         (uint8_t)pgm_read_byte(&gfxFont->yAdvance);
         } else if(c != '\r') {
-            uint8_t first = pgm_read_byte(&gfxFont->first);
-            if((c >= first) && (c <= (uint8_t)pgm_read_byte(&gfxFont->last))) {
+            uint16_t first = pgm_read_word(&gfxFont->first);
+            if((c >= first) && (c <= pgm_read_word(&gfxFont->last))) {
                 GFXglyph *glyph = &(((GFXglyph *)pgm_read_pointer(
                   &gfxFont->glyph))[c - first]);
                 uint8_t   w     = pgm_read_byte(&glyph->width),
@@ -1406,8 +1406,8 @@ void Adafruit_GFX::charBounds(char c, int16_t *x, int16_t *y,
             *x  = 0;    // Reset x to zero, advance y by one line
             *y += textsize * (uint8_t)pgm_read_byte(&gfxFont->yAdvance);
         } else if(c != '\r') { // Not a carriage return; is normal char
-            uint8_t first = pgm_read_byte(&gfxFont->first),
-                    last  = pgm_read_byte(&gfxFont->last);
+            uint16_t first = pgm_read_word(&gfxFont->first),
+                     last  = pgm_read_word(&gfxFont->last);
             if((c >= first) && (c <= last)) { // Char present in this font?
                 GFXglyph *glyph = &(((GFXglyph *)pgm_read_pointer(
                   &gfxFont->glyph))[c - first]);

--- a/Adafruit_GFX.h
+++ b/Adafruit_GFX.h
@@ -109,6 +109,8 @@ class Adafruit_GFX : public Print {
     getTextBounds(const String &str, int16_t x, int16_t y,
       int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h);
 
+  // Serial UTF-8 decoder
+  uint16_t decodeUTF8(uint8_t c);
 
 #if ARDUINO >= 100
   virtual size_t write(uint8_t);
@@ -148,6 +150,9 @@ class Adafruit_GFX : public Print {
     _cp437;         ///< If set, use correct CP437 charset (default is off)
   GFXfont
     *gfxFont;       ///< Pointer to special font
+
+  uint8_t  decoderState = 0;   // UTF-8 decoder state
+  uint16_t decoderBuffer;      // Unicode code-point buffer
 };
 
 

--- a/Adafruit_GFX.h
+++ b/Adafruit_GFX.h
@@ -93,7 +93,7 @@ class Adafruit_GFX : public Print {
       int16_t w, int16_t h),
     drawRGBBitmap(int16_t x, int16_t y,
       uint16_t *bitmap, uint8_t *mask, int16_t w, int16_t h),
-    drawChar(int16_t x, int16_t y, unsigned char c, uint16_t color,
+    drawChar(int16_t x, int16_t y, uint16_t c, uint16_t color,
       uint16_t bg, uint8_t size),
     setCursor(int16_t x, int16_t y),
     setTextColor(uint16_t c),

--- a/gfxfont.h
+++ b/gfxfont.h
@@ -21,8 +21,8 @@ typedef struct {
 typedef struct { 
 	uint8_t  *bitmap;      ///< Glyph bitmaps, concatenated
 	GFXglyph *glyph;       ///< Glyph array
-	uint8_t   first;       ///< ASCII extents (first char)
-        uint8_t   last;        ///< ASCII extents (last char)
+	uint16_t   first;       ///< ASCII extents (first char)
+        uint16_t   last;        ///< ASCII extents (last char)
 	uint8_t   yAdvance;    ///< Newline distance (y axis)
 } GFXfont;
 


### PR DESCRIPTION
UTF-8 decoder added to print stream so the UTF-8 encoded Unicode strings produced by the compiler are rendered correctly on the graphical displays.

Example for ILI9341 TFT showing printing Hiragana characters to screen here:

[hiragana_example.zip](https://github.com/adafruit/Adafruit-GFX-Library/files/2848269/hiragana_example.zip)


This update makes glyphs from the entire 16 bit Unicode Basic Multilingual Plane available. See comments in the example. This example uses ~45% of FLASH on an UNO so it should run fine on any hardware. The included font files were generated by fontconvert tool with the Unicode Hiragana code point range of 12353 - 12435.