### PR TITLE
Teensy T4.0 support

### DIFF
--- a/Adafruit_SPITFT.cpp
+++ b/Adafruit_SPITFT.cpp
@@ -120,6 +120,8 @@ Adafruit_SPITFT::Adafruit_SPITFT(uint16_t w, uint16_t h,
   #if defined(CORE_TEENSY)
    #if !defined(KINETISK)
     dcPinMask          = digitalPinToBitMask(dc);
+    swspi.sckPinMask   = digitalPinToBitMask(sck);
+    swspi.mosiPinMask  = digitalPinToBitMask(mosi);
    #endif
     dcPortSet          = portSetRegister(dc);
     dcPortClr          = portClearRegister(dc);
@@ -142,6 +144,9 @@ Adafruit_SPITFT::Adafruit_SPITFT(uint16_t w, uint16_t h,
     }
     if(miso >= 0) {
         swspi.misoPort = portInputRegister(miso);
+        #if !defined(KINETISK)
+        swspi.misoPinMask = digitalPinToBitMask(miso);
+        #endif
     } else {
         swspi.misoPort = portInputRegister(dc);
     }
@@ -1981,6 +1986,9 @@ inline void Adafruit_SPITFT::SPI_SCK_HIGH(void) {
     *swspi.sckPortSet = 1;
   #else  // !KINETISK
     *swspi.sckPortSet = swspi.sckPinMask;
+    #if defined(__IMXRT1052__) || defined(__IMXRT1062__)  // Teensy 4.x
+    for(volatile uint8_t i=0; i<1; i++);
+    #endif  
   #endif
  #else  // !HAS_PORT_SET_CLR
     *swspi.sckPort   |= swspi.sckPinMaskSet;
@@ -2003,6 +2011,9 @@ inline void Adafruit_SPITFT::SPI_SCK_LOW(void) {
     *swspi.sckPortClr = 1;
   #else  // !KINETISK
     *swspi.sckPortClr = swspi.sckPinMask;
+    #if defined(__IMXRT1052__) || defined(__IMXRT1062__)  // Teensy 4.x
+    for(volatile uint8_t i=0; i<1; i++);
+    #endif  
   #endif
  #else  // !HAS_PORT_SET_CLR
     *swspi.sckPort   &= swspi.sckPinMaskClr;

--- a/Adafruit_SPITFT.h
+++ b/Adafruit_SPITFT.h
@@ -40,8 +40,13 @@
   #define USE_FAST_PINIO             ///< Use direct PORT register access
   #define HAS_PORT_SET_CLR           ///< PORTs have set & clear registers
  #elif defined(CORE_TEENSY)
+  // PJRC Teensy 4.x
+  #if defined(__IMXRT1052__) || defined(__IMXRT1062__)  // Teensy 4.x
+  typedef uint32_t PORT_t;            ///< PORT values are 32-bit
   // PJRC Teensy 3.x
+  #else
   typedef uint8_t PORT_t;            ///< PORT values are 8-bit
+  #endif
   #define USE_FAST_PINIO             ///< Use direct PORT register access
   #define HAS_PORT_SET_CLR           ///< PORTs have set & clear registers
  #else
@@ -428,13 +433,24 @@ class Adafruit_SPITFT : public Adafruit_GFX {
       } swspi;                     ///< Software SPI values
       struct {                     //   Values specific to 8-bit parallel:
 #if defined(USE_FAST_PINIO)
+
+  #if defined(__IMXRT1052__) || defined(__IMXRT1062__)  // Teensy 4.x
+        volatile uint32_t *writePort; ///< PORT register for DATA WRITE
+        volatile uint32_t *readPort;  ///< PORT (PIN) register for DATA READ
+  #else
         volatile uint8_t *writePort; ///< PORT register for DATA WRITE
         volatile uint8_t *readPort;  ///< PORT (PIN) register for DATA READ
+  #endif      
 #if defined(HAS_PORT_SET_CLR)
         // Port direction register pointers are always 8-bit regardless of
         // PORTreg_t -- even if 32-bit port, we modify a byte-aligned 8 bits.
+  #if defined(__IMXRT1052__) || defined(__IMXRT1062__)  // Teensy 4.x
+        volatile uint32_t *dirSet;  ///< PORT byte data direction SET
+        volatile uint32_t *dirClr;  ///< PORT byte data direction CLEAR
+  #else
         volatile uint8_t *dirSet;  ///< PORT byte data direction SET
         volatile uint8_t *dirClr;  ///< PORT byte data direction CLEAR
+  #endif      
         PORTreg_t wrPortSet;       ///< PORT register for write strobe SET
         PORTreg_t wrPortClr;       ///< PORT register for write strobe CLEAR
         PORTreg_t rdPortSet;       ///< PORT register for read strobe SET

--- a/glcdfont.c
+++ b/glcdfont.c
@@ -9,6 +9,10 @@
  #include <avr/pgmspace.h>
 #elif defined(ESP8266)
  #include <pgmspace.h>
+#elif defined(__IMXRT1052__) || defined(__IMXRT1062__)
+// PROGMEM is defefind for T4 to place data in specific memory section
+ #undef PROGMEM
+ #define PROGMEM
 #else
  #define PROGMEM
 #endif


### PR DESCRIPTION
The Teensy T4 (__IMXRT1062__) port registers need to be 32 bits unlike the Teensy 3.x which are 8 bits.

adafruit_ili9341  and adafruit_st7735 libraries graphic test

Removed compiler warning

that PROGMEM was previously defined.  So undefine it first...

Note: Thought of simply doing nothing here
(do neither the #undef nor the #define).

But that gives compiler error

Teensy T4 - Make Bit Bang version work.

With T4, the Port/Set registers are masks not single value.

So need to setup those class variables:

Also found that bitbang of T4, was too fast for display, so put in same slow
down that ESP32 has, which gets the clock down to mayby 12.5mhz

Tried these changes out with both:
adafruit_ili9341  and adafruit_st7735 libraries graphic test

Update comments