### PR TITLE
Replaced the "GFX DMA IS ENABLED" pragma message

### DIFF
--- a/Adafruit_SPITFT.cpp
+++ b/Adafruit_SPITFT.cpp
@@ -43,6 +43,7 @@
 #endif // end PORT_IOBUS
 
 #if defined(USE_SPI_DMA)
+ #pragma message ("GFX DMA IS ENABLED. HIGHLY EXPERIMENTAL.")
  #include <Adafruit_ZeroDMA.h>
  #include "wiring_private.h"  // pinPeripheral() function
  #include <malloc.h>          // memalign() function

--- a/Adafruit_SPITFT.h
+++ b/Adafruit_SPITFT.h
@@ -82,7 +82,6 @@ typedef volatile  PORT_t* PORTreg_t; ///< PORT register type
 #endif
 
 #if defined(USE_SPI_DMA)
- #pragma message ("GFX DMA IS ENABLED. HIGHLY EXPERIMENTAL.")
  #include <Adafruit_ZeroDMA.h>
 #endif
 


### PR DESCRIPTION
Got really annoyed by the "  #pragma message ("GFX DMA IS ENABLED. HIGHLY EXPERIMENTAL.") " showing up about 20 times every time I compiled.
Now shows up only once!