### PR TITLE
UTF-8 support

### DIFF
--- a/Adafruit_GFX.cpp
+++ b/Adafruit_GFX.cpp
@@ -2011,4 +2011,4 @@ void GFXcanvas16::byteSwap(void) {
         uint32_t i, pixels = WIDTH * HEIGHT;
         for(i=0; i<pixels; i++) buffer[i] = __builtin_bswap16(buffer[i]);
     }
-} 
+}

--- a/Adafruit_GFX.cpp
+++ b/Adafruit_GFX.cpp
@@ -112,6 +112,7 @@ WIDTH(w), HEIGHT(h)
     textcolor = textbgcolor = 0xFFFF;
     wrap      = true;
     _cp437    = false;
+    _utf8     = false;
     gfxFont   = NULL;
 }
 
@@ -1048,13 +1049,13 @@ void Adafruit_GFX::drawRGBBitmap(int16_t x, int16_t y,
    @brief   Draw a single character
     @param    x   Bottom left corner x coordinate
     @param    y   Bottom left corner y coordinate
-    @param    c   The 8-bit font-indexed character (likely ascii)
+    @param    c   The 16-bit font-indexed character
     @param    color 16-bit 5-6-5 Color to draw chraracter with
     @param    bg 16-bit 5-6-5 Color to fill background with (if same as color, no background)
     @param    size  Font magnification level, 1 is 'original' size
 */
 /**************************************************************************/
-void Adafruit_GFX::drawChar(int16_t x, int16_t y, unsigned char c,
+void Adafruit_GFX::drawChar(int16_t x, int16_t y, uint16_t c,
   uint16_t color, uint16_t bg, uint8_t size) {
     drawChar(x, y, c, color, bg, size, size);
 }
@@ -1065,14 +1066,14 @@ void Adafruit_GFX::drawChar(int16_t x, int16_t y, unsigned char c,
    @brief   Draw a single character
     @param    x   Bottom left corner x coordinate
     @param    y   Bottom left corner y coordinate
-    @param    c   The 8-bit font-indexed character (likely ascii)
+    @param    c   The 16-bit font-indexed character
     @param    color 16-bit 5-6-5 Color to draw chraracter with
     @param    bg 16-bit 5-6-5 Color to fill background with (if same as color, no background)
     @param    size_x  Font magnification level in X-axis, 1 is 'original' size
     @param    size_y  Font magnification level in Y-axis, 1 is 'original' size
 */
 /**************************************************************************/
-void Adafruit_GFX::drawChar(int16_t x, int16_t y, unsigned char c,
+void Adafruit_GFX::drawChar(int16_t x, int16_t y, uint16_t c,
   uint16_t color, uint16_t bg, uint8_t size_x, uint8_t size_y) {
 
     if(!gfxFont) { // 'Classic' built-in font
@@ -1114,9 +1115,10 @@ void Adafruit_GFX::drawChar(int16_t x, int16_t y, unsigned char c,
         // newlines, returns, non-printable characters, etc.  Calling
         // drawChar() directly with 'bad' characters of font may cause mayhem!
 
-        c -= (uint8_t)pgm_read_byte(&gfxFont->first);
-        GFXglyph *glyph  = pgm_read_glyph_ptr(gfxFont, c);
-        uint8_t  *bitmap = pgm_read_bitmap_ptr(gfxFont);
+        c -= pgm_read_word(&gfxFont->first);
+        GFXglyph *glyph  = &(((GFXglyph *)pgm_read_pointer(&gfxFont->glyph))[c]);
+        uint8_t  *bitmap = (uint8_t *)pgm_read_pointer(&gfxFont->bitmap);
+
 
         uint16_t bo = pgm_read_word(&glyph->bitmapOffset);
         uint8_t  w  = pgm_read_byte(&glyph->width),
@@ -1170,15 +1172,86 @@ void Adafruit_GFX::drawChar(int16_t x, int16_t y, unsigned char c,
 
     } // End classic vs custom font
 }
+
+
+/**************************************************************************/
+/*!
+    @brief  Serial UTF-8 decoder
+    @param  c  8 bit value from encoded stream
+    @returns   0 if decoding is not complete yet, 16 bit code point
+               otherwise. Can cast to 8 bits for ASCII range (0-255)
+*/
+/**************************************************************************/
+
+uint16_t Adafruit_GFX::decodeUTF8(uint8_t c)
+{
+    // 7 bit Unicode Code Point
+    if ((c & 0x80) == 0x00) {
+        decoderState = 0;
+        return (uint16_t)c;
+    }
+
+    if (decoderState == 0)
+    {
+        // 11 bit Unicode Code Point
+        if ((c & 0xE0) == 0xC0)
+        {
+            decoderBuffer = ((c & 0x1F)<<6); // Save first 5 bits
+            decoderState = 1;
+            return 0;
+        }
+
+        // 16 bit Unicode Code Point
+        if ((c & 0xF0) == 0xE0)
+        {
+            decoderBuffer = ((c & 0x0F)<<12);  // Save first 4 bits
+            decoderState = 2;
+            return 0;
+        }
+
+        // 21 bit Unicode  Code Point not supported so fall-back to extended ASCII
+        if ((c & 0xF8) == 0xF0) return (uint16_t)c;
+    }
+    else
+    {
+        if (decoderState == 2)
+        {
+            decoderBuffer |= ((c & 0x3F)<<6); // Add next 6 bits of 16 bit code point
+            decoderState--;
+            return 0;
+        }
+        else // decoderState must be == 1
+        {
+            decoderBuffer |= (c & 0x3F); // Add last 6 bits of code point
+            decoderState = 0;
+            return decoderBuffer;
+        }
+    }
+
+    decoderState = 0;
+
+    return (uint16_t)c; // fall-back to extended ASCII
+}
+
+
+
+
+
+
 /**************************************************************************/
 /*!
     @brief  Print one byte/character of data, used to support print()
-    @param  c  The 8-bit ascii character to write
+    @param  utf8  The 8-bit UTF-8 or ascii code
 */
 /**************************************************************************/
-size_t Adafruit_GFX::write(uint8_t c) {
-    if(!gfxFont) { // 'Classic' built-in font
+size_t Adafruit_GFX::write(uint8_t data) {
 
+    uint16_t c = (uint16_t)data;
+    if (_utf8) c = decodeUTF8(data);
+    if (c == 0) return 1;
+
+    if(!gfxFont) { // 'Classic' built-in font
+        if (c > 255) return 1;                 // Stop 16 bit characters
         if(c == '\n') {                        // Newline?
             cursor_x  = 0;                     // Reset x to zero,
             cursor_y += textsize_y * 8;        // advance y one line
@@ -1198,9 +1271,9 @@ size_t Adafruit_GFX::write(uint8_t c) {
             cursor_y += (int16_t)textsize_y *
                         (uint8_t)pgm_read_byte(&gfxFont->yAdvance);
         } else if(c != '\r') {
-            uint8_t first = pgm_read_byte(&gfxFont->first);
-            if((c >= first) && (c <= (uint8_t)pgm_read_byte(&gfxFont->last))) {
-                GFXglyph *glyph  = pgm_read_glyph_ptr(gfxFont, c - first);
+            uint16_t first = pgm_read_word(&gfxFont->first);
+            if((c >= first) && (c <= pgm_read_word(&gfxFont->last))) {
+                GFXglyph *glyph = &(((GFXglyph *)pgm_read_pointer(&gfxFont->glyph))[c - first]);
                 uint8_t   w     = pgm_read_byte(&glyph->width),
                           h     = pgm_read_byte(&glyph->height);
                 if((w > 0) && (h > 0)) { // Is there an associated bitmap?
@@ -1263,6 +1336,7 @@ void Adafruit_GFX::setRotation(uint8_t x) {
             break;
     }
 }
+
 
 /**************************************************************************/
 /*!
@@ -1937,4 +2011,4 @@ void GFXcanvas16::byteSwap(void) {
         uint32_t i, pixels = WIDTH * HEIGHT;
         for(i=0; i<pixels; i++) buffer[i] = __builtin_bswap16(buffer[i]);
     }
-}
+} 

--- a/Adafruit_GFX.h
+++ b/Adafruit_GFX.h
@@ -9,6 +9,7 @@
 #endif
 #include "gfxfont.h"
 
+
 /// A generic graphics superclass that can handle all sorts of drawing. At a minimum you can subclass and provide drawPixel(). At a maximum you can do a ton of overriding to optimize. Used for any/all Adafruit displays!
 class Adafruit_GFX : public Print {
 
@@ -93,9 +94,9 @@ class Adafruit_GFX : public Print {
       int16_t w, int16_t h),
     drawRGBBitmap(int16_t x, int16_t y,
       uint16_t *bitmap, uint8_t *mask, int16_t w, int16_t h),
-    drawChar(int16_t x, int16_t y, unsigned char c, uint16_t color,
+    drawChar(int16_t x, int16_t y, uint16_t c, uint16_t color,
       uint16_t bg, uint8_t size),
-    drawChar(int16_t x, int16_t y, unsigned char c, uint16_t color,
+    drawChar(int16_t x, int16_t y, uint16_t c, uint16_t color,
 	      uint16_t bg, uint8_t size_x, uint8_t size_y),
     getTextBounds(const char *string, int16_t x, int16_t y,
       int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h),
@@ -106,6 +107,10 @@ class Adafruit_GFX : public Print {
     setTextSize(uint8_t s),
     setTextSize(uint8_t sx, uint8_t sy),
     setFont(const GFXfont *f = NULL);
+
+  // Serial UTF-8 decoder
+  uint16_t decodeUTF8(uint8_t c);
+
 
   /**********************************************************************/
   /*!
@@ -163,6 +168,18 @@ class Adafruit_GFX : public Print {
   /**********************************************************************/
   void cp437(boolean x=true) { _cp437 = x; }
 
+ /**********************************************************************/
+  /*!
+    @brief  Enable (or disable) UTF-8-compatible charset in custom made fonts
+            By default, the font.h files boundled to the library use ASCII charset
+	    as UTF-8 fonts need more memory as many AVR chips can offer.
+            Pass 'true' to this function if you are willing to use UTF-8 fonts that
+            you generated whith fontconvert and also your board has enough free memory.
+    @param  x  true = enable (new behavior), false = disable (old behavior)
+  */
+  /**********************************************************************/
+  void utf8(boolean x=true) { _utf8 = x; }
+
 #if ARDUINO >= 100
   virtual size_t write(uint8_t);
 #else
@@ -211,6 +228,10 @@ class Adafruit_GFX : public Print {
   /************************************************************************/
   int16_t getCursorY(void) const { return cursor_y; };
 
+  // Set or get an arbitrary library attribute or configuration option
+  void    setAttribute(uint8_t id = 0, uint8_t a = 0);
+  uint8_t getAttribute(uint8_t id = 0);
+
  protected:
   void
     charBounds(char c, int16_t *x, int16_t *y,
@@ -232,9 +253,14 @@ class Adafruit_GFX : public Print {
     rotation;       ///< Display rotation (0 thru 3)
   boolean
     wrap,           ///< If set, 'wrap' text at right edge of display
-    _cp437;         ///< If set, use correct CP437 charset (default is off)
+    _cp437,         ///< If set, use correct CP437 charset (default is off)
+    _utf8;         ///< If set, use correct UTF charset (default is off)
   GFXfont
     *gfxFont;       ///< Pointer to special font
+
+  uint8_t  decoderState = 0;   // UTF-8 decoder state
+  uint16_t decoderBuffer;      // Unicode code-point buffer
+
 };
 
 
@@ -350,4 +376,4 @@ class GFXcanvas16 : public Adafruit_GFX {
   uint16_t *buffer;
 };
 
-#endif // _ADAFRUIT_GFX_H
+#endif // _ADAFRUIT_GFX_H 

--- a/Adafruit_GFX.h
+++ b/Adafruit_GFX.h
@@ -376,4 +376,4 @@ class GFXcanvas16 : public Adafruit_GFX {
   uint16_t *buffer;
 };
 
-#endif // _ADAFRUIT_GFX_H 
+#endif // _ADAFRUIT_GFX_H


### PR DESCRIPTION
Wanted to display glyphs from font.h files generated from UTF-8 font.ttf files.
Found some discussions in #185 suggesting the use of iso-8859-x chars, which IMHO is not a good idea (one needs to find a proper tool to convert UTF-8 .ttf files to iso first, then generate the font.h files, that will be still larger as the ASCII font.h files boundled with the library. Even in that case you might end up not beeing able to display a glyph if your iso-8859-x coded font did contain it. Of course a font.h generated from a UTF-8 .ttf will need more memory, but it's 2019 and newer boards tend to have a right amount of memory).

While looking for a solution i also found #200 from Bodmer who also provided me some help. He forked V1.3.6 and modified it but that version does not compile on my board... and since that version even the code has been reordered here in master branch...

So i ended up comparing Bodmer's modified version with the original master and as result here is my PR that enables UTF-8 with custom made fonts, while not changing anything with the default fonts.

Tested with a MAX32630FTHR and 2.13" Flexible Monochrome eInk / ePaper Display. Works as expected even without modifing gfxfont.h file suggested in #185 


Please test on other boards/display combinations and merge ;-)