### PR TITLE
Change in character size on button label

### DIFF
--- a/Adafruit_GFX.cpp
+++ b/Adafruit_GFX.cpp
@@ -1575,7 +1575,7 @@ void Adafruit_GFX_Button::initButtonUL(
   _textsize_x   = textsize_x;
   _textsize_y   = textsize_y;
   _gfx          = gfx;
-  strncpy(_label, label, 9);
+  strcpy(_label, label);
 }
 
 /**************************************************************************/


### PR DESCRIPTION
I have been testing the **Adafruit_GFX_Button** function and I noticed that the button label cannot exceed 9 characters. I have changed the library to allow a greater range using the **strcpy()** function instead of **strncpy()**.
Nestor Palomeque.