### PR TITLE
Added previously removed sendCommand() overload to fix rotation issue.

### DIFF
--- a/Adafruit_SPITFT.cpp
+++ b/Adafruit_SPITFT.cpp
@@ -1762,6 +1762,37 @@ uint16_t Adafruit_SPITFT::color565(uint8_t red, uint8_t green, uint8_t blue) {
 }
 
 /*!
+@brief   Adafruit_SPITFT Send Command handles complete sending of commands and data
+@param   commandByte       The Command Byte
+@param   dataBytes         A pointer to the Data bytes to send
+@param   numDataBytes      The number of bytes we should send
+*/
+void Adafruit_SPITFT::sendCommand(uint8_t commandByte, uint8_t *dataBytes, uint8_t numDataBytes) {
+    SPI_BEGIN_TRANSACTION();
+    if(_cs >= 0) SPI_CS_LOW();
+
+    SPI_DC_LOW(); // Command mode
+    spiWrite(commandByte); // Send the command byte
+
+    SPI_DC_HIGH();
+    for (int i=0; i<numDataBytes; i++) {
+      spiWrite(*dataBytes); // Send the data bytes
+      dataBytes++;
+      if((connection == TFT_PARALLEL) && tft8.wide) {
+        SPI_WRITE16(*(uint16_t *)dataBytes);
+        dataBytes += 2;
+      } else {
+        spiWrite(*dataBytes); // Send the data bytes
+        dataBytes++;
+      }
+    }
+
+    if(_cs >= 0) SPI_CS_HIGH();
+    SPI_END_TRANSACTION();
+}
+
+
+/*!
  @brief   Adafruit_SPITFT Send Command handles complete sending of commands and data
  @param   commandByte       The Command Byte
  @param   dataBytes         A pointer to the Data bytes to send

--- a/Adafruit_SPITFT.h
+++ b/Adafruit_SPITFT.h
@@ -194,6 +194,7 @@ class Adafruit_SPITFT : public Adafruit_GFX {
     void         startWrite(void);
     // Chip deselect and/or hardware SPI transaction end as needed:
     void         endWrite(void);
+    void         sendCommand(uint8_t commandByte, uint8_t *dataBytes, uint8_t numDataBytes);
     void         sendCommand(uint8_t commandByte, const uint8_t *dataBytes = NULL, uint8_t numDataBytes = 0);
     void         sendCommand16(uint16_t commandWord, const uint8_t *dataBytes = NULL, uint8_t numDataBytes = 0);
     uint8_t      readcommand8(uint8_t commandByte, uint8_t index = 0);


### PR DESCRIPTION
This function was removed in a previous PR where 16-bit reads were added. It appears it was an attempt to combine 2 similar functions in 1, but that broke some stuff. This fix works great on normal usage for 8-bit procs, but I have not tested it in parallel as I'm not quite sure what the conditions are for that. I also tested this on a Metro M4 and PyPortal just for a bit of variety and both tested fine. 