### PR TITLE
Fix two compiler warnings.

### DIFF
--- a/Adafruit_SPITFT.cpp
+++ b/Adafruit_SPITFT.cpp
@@ -2114,7 +2114,6 @@ void Adafruit_SPITFT::writeCommand16(uint16_t cmd) {
              not supported by the MCU architecture).
 */
 uint16_t Adafruit_SPITFT::read16(void) {
-    uint8_t  b = 0;
     uint16_t w = 0;
     if(connection == TFT_PARALLEL) {
         if(tft8._rd >= 0) {

--- a/glcdfont.c
+++ b/glcdfont.c
@@ -277,4 +277,11 @@ static const unsigned char font[] PROGMEM = {
 	0x00, 0x3C, 0x3C, 0x3C, 0x3C,
 	0x00, 0x00, 0x00, 0x00, 0x00  // #255 NBSP
 };
+
+// allow clean compilation with [-Wunused-const-variable=] and [-Wall]
+static inline void avoid_unused_const_variable_compiler_warning(void)
+{
+	(void)font;
+}
+
 #endif // FONT5X7_H


### PR DESCRIPTION
These are showing up in the error logs when building Adafruit_nRF52_Arduino (currently in the "allowed to fail" list).  See, for example, https://travis-ci.com/adafruit/Adafruit_nRF52_Arduino/builds/141897263.