### PR TITLE
allow Print's overloaded write() calls to be used with Adafruit_GFX

### DIFF
--- a/Adafruit_GFX.h
+++ b/Adafruit_GFX.h
@@ -163,6 +163,7 @@ class Adafruit_GFX : public Print {
   /**********************************************************************/
   void cp437(boolean x=true) { _cp437 = x; }
 
+  using Print::write;
 #if ARDUINO >= 100
   virtual size_t write(uint8_t);
 #else


### PR DESCRIPTION
Adafruit_GFX overrides one of the Print::write() functions.
The rules of overload resolution say that all the overloaded options
need to be visible in the class where the first option is found.
Since Adafruit_GFX only overrides write(uint8_t), the other version,
write(const uint8_t *buffer, size_t size) cannot be called on a
Adafruit_GFX display from sketches.

This change adds the "using" directive, which tells C++ to consider
all of Print's write members to be in scope of Adafruit_GFX, even
though only one is overridden.