### PR TITLE
getTextBounds method that uses internal cursor values

### DIFF
--- a/Adafruit_GFX.cpp
+++ b/Adafruit_GFX.cpp
@@ -1475,9 +1475,9 @@ void Adafruit_GFX::getTextBounds(const char *str, int16_t x, int16_t y,
     @param    h      The boundary height, set by function
 */
 /**************************************************************************/
-void Adafruit_GFX::getTextBounds(const char *str, int16_t *x1, int16_t *y1, 
+void Adafruit_GFX::getTextBounds(const char *str, int16_t *x1, int16_t *y1,
                                  uint16_t *w, uint16_t *h) {
-    getTextBounds(str, cursor_x, cursor_y, x1, y1, w, h);
+  getTextBounds(str, cursor_x, cursor_y, x1, y1, w, h);
 }
 
 /**************************************************************************/

--- a/Adafruit_GFX.cpp
+++ b/Adafruit_GFX.cpp
@@ -1467,6 +1467,22 @@ void Adafruit_GFX::getTextBounds(const char *str, int16_t x, int16_t y,
 /**************************************************************************/
 /*!
     @brief    Helper to determine size of a string with current font/size. Pass
+   string, uses current cursor positions, returns UL corner and W,H.
+    @param    str     The ascii string to measure
+    @param    x1      The boundary X coordinate, set by function
+    @param    y1      The boundary Y coordinate, set by function
+    @param    w      The boundary width, set by function
+    @param    h      The boundary height, set by function
+*/
+/**************************************************************************/
+void Adafruit_GFX::getTextBounds(const char *str, int16_t *x1, int16_t *y1, 
+                                 uint16_t *w, uint16_t *h) {
+    getTextBounds(str, cursor_x, cursor_y, x1, y1, w, h);
+}
+
+/**************************************************************************/
+/*!
+    @brief    Helper to determine size of a string with current font/size. Pass
    string and a cursor position, returns UL corner and W,H.
     @param    str    The ascii string to measure (as an arduino String() class)
     @param    x      The current cursor X

--- a/Adafruit_GFX.h
+++ b/Adafruit_GFX.h
@@ -104,6 +104,8 @@ public:
                uint16_t bg, uint8_t size_x, uint8_t size_y),
       getTextBounds(const char *string, int16_t x, int16_t y, int16_t *x1,
                     int16_t *y1, uint16_t *w, uint16_t *h),
+      getTextBounds(const char *str, int16_t *x1, int16_t *y1, uint16_t *w,
+                    uint16_t *h),
       getTextBounds(const __FlashStringHelper *s, int16_t x, int16_t y,
                     int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h),
       getTextBounds(const String &str, int16_t x, int16_t y, int16_t *x1,


### PR DESCRIPTION
Simpler method call that uses current cursor values.
Useful when you want to get the size of string you are about to print.