### PR TITLE
Removed duplicate spiWrite to fix bbSPI

### DIFF
--- a/Adafruit_SPITFT.cpp
+++ b/Adafruit_SPITFT.cpp
@@ -1846,8 +1846,6 @@ void Adafruit_SPITFT::sendCommand(uint8_t commandByte, uint8_t *dataBytes,
 
   SPI_DC_HIGH();
   for (int i = 0; i < numDataBytes; i++) {
-    spiWrite(*dataBytes); // Send the data bytes
-    dataBytes++;
     if ((connection == TFT_PARALLEL) && tft8.wide) {
       SPI_WRITE16(*(uint16_t *)dataBytes);
       dataBytes += 2;


### PR DESCRIPTION
When examining the code and comparing it to the old working code, I noticed there was a duplicate spiWrite. I removed it and it solved the bbSPI issue I was seeing. I also tested on hardware SPI and that worked fine.

Fixes https://github.com/adafruit/Adafruit-SSD1351-library/issues/27.

I tested on SSD1351 using software and hardware SPI with an Adafruit Metro.