### PR TITLE
Change "char" to "unsigned char" in charBounds()

### DIFF
--- a/Adafruit_GFX.cpp
+++ b/Adafruit_GFX.cpp
@@ -1364,7 +1364,7 @@ void Adafruit_GFX::setFont(const GFXfont *f) {
     @param    maxy  Maximum clipping value for Y
 */
 /**************************************************************************/
-void Adafruit_GFX::charBounds(char c, int16_t *x, int16_t *y, int16_t *minx,
+void Adafruit_GFX::charBounds(unsigned char c, int16_t *x, int16_t *y, int16_t *minx,
                               int16_t *miny, int16_t *maxx, int16_t *maxy) {
 
   if (gfxFont) {

--- a/Adafruit_GFX.cpp
+++ b/Adafruit_GFX.cpp
@@ -1364,8 +1364,9 @@ void Adafruit_GFX::setFont(const GFXfont *f) {
     @param    maxy  Maximum clipping value for Y
 */
 /**************************************************************************/
-void Adafruit_GFX::charBounds(unsigned char c, int16_t *x, int16_t *y, int16_t *minx,
-                              int16_t *miny, int16_t *maxx, int16_t *maxy) {
+void Adafruit_GFX::charBounds(unsigned char c, int16_t *x, int16_t *y,
+                              int16_t *minx, int16_t *miny, int16_t *maxx,
+                              int16_t *maxy) {
 
   if (gfxFont) {
 

--- a/Adafruit_GFX.h
+++ b/Adafruit_GFX.h
@@ -220,8 +220,8 @@ public:
   int16_t getCursorY(void) const { return cursor_y; };
 
 protected:
-  void charBounds(unsigned char c, int16_t *x, int16_t *y, int16_t *minx, int16_t *miny,
-                  int16_t *maxx, int16_t *maxy);
+  void charBounds(unsigned char c, int16_t *x, int16_t *y, int16_t *minx,
+                  int16_t *miny, int16_t *maxx, int16_t *maxy);
   int16_t WIDTH,      ///< This is the 'raw' display width - never changes
       HEIGHT;         ///< This is the 'raw' display height - never changes
   int16_t _width,     ///< Display width as modified by current rotation

--- a/Adafruit_GFX.h
+++ b/Adafruit_GFX.h
@@ -220,7 +220,7 @@ public:
   int16_t getCursorY(void) const { return cursor_y; };
 
 protected:
-  void charBounds(char c, int16_t *x, int16_t *y, int16_t *minx, int16_t *miny,
+  void charBounds(unsigned char c, int16_t *x, int16_t *y, int16_t *minx, int16_t *miny,
                   int16_t *maxx, int16_t *maxy);
   int16_t WIDTH,      ///< This is the 'raw' display width - never changes
       HEIGHT;         ///< This is the 'raw' display height - never changes


### PR DESCRIPTION
I saw that `getTextBounds()` skips characters above 0x80. Problem lies in `charBounds()`, where character is compared with first and end character in font, but `char` is signed and characters above 0x80 are out of range because are negative.

I've changed signature to `unsigned char` and works for me.

C++ is not my primary language, so please let me know if my approach is wrong and should be fixed in different way.