### PR TITLE
add virtual functions for porting to various hardware platforms.

### DIFF
--- a/Adafruit_GFX.h
+++ b/Adafruit_GFX.h
@@ -17,6 +17,12 @@ class Adafruit_GFX : public Print {
 public:
   Adafruit_GFX(int16_t w, int16_t h); // Constructor
 
+  // some subclass need following functions, and it make it easer to port applications to other hardware platforms.
+  virtual boolean begin() {return true;}
+  virtual void end() {}
+  virtual void display() {}
+  virtual void clear() { fillRect(0,0, _width,_height, 0); }
+
   // This MUST be defined by the subclass:
   virtual void drawPixel(
       int16_t x, int16_t y,

--- a/Adafruit_SPITFT.h
+++ b/Adafruit_SPITFT.h
@@ -163,6 +163,7 @@ public:
       @param  freq  SPI frequency, in hz (or 0 for default or unused).
   */
   virtual void begin(uint32_t freq) = 0;
+  virtual boolean begin() { begin(0); return true; }
 
   /*!
       @brief  Set up the specific display hardware's "address window"


### PR DESCRIPTION
This patch is to add several APIs to uniform the control logic of some device driver subclasses, and help to easy port the application to various hardware platforms.
* begin()/end() some device driver use it to allocate resources. such as SSD1306.
* display() some driver need this function to sync the internal memory with the real LCD device.
* clear() provides a fast way to clean the screen

Some device subclass need to be adjusted according to the APIs. For example, an begin() function needed adding to the device driver SSD1306 to porting the app code to other platform, such as ILI9341.

This patch was tested with SSD1306 and ILI9341.
