### PR TITLE
Break up the compound decls in the `BASIC DRAW API` section

### DIFF
--- a/Adafruit_GFX.h
+++ b/Adafruit_GFX.h
@@ -17,13 +17,16 @@ class Adafruit_GFX : public Print {
 public:
   Adafruit_GFX(int16_t w, int16_t h); // Constructor
 
-  // This MUST be defined by the subclass:
-  virtual void drawPixel(
-      int16_t x, int16_t y,
-      uint16_t color) = 0; ///< Virtual drawPixel() function to draw to the
-                           ///< screen/framebuffer/etc, must be overridden in
-                           ///< subclass. @param x X coordinate.  @param y Y
-                           ///< coordinate. @param color 16-bit pixel color.
+  /**********************************************************************/
+  /*!
+    @brief  Draw to the screen/framebuffer/etc.
+    Must be overridden in subclass.
+    @param  x    X coordinate in pixels
+    @param  y    Y coordinate in pixels
+    @param color  16-bit pixel color.
+  */
+  /**********************************************************************/
+  virtual void drawPixel(int16_t x, int16_t y, uint16_t color) = 0;
 
   // TRANSACTION API / CORE DRAW API
   // These MAY be overridden by the subclass to provide device-specific
@@ -47,69 +50,72 @@ public:
   // BASIC DRAW API
   // These MAY be overridden by the subclass to provide device-specific
   // optimized code.  Otherwise 'generic' versions are used.
-  virtual void
+
   // It's good to implement those, even if using transaction API
-  drawFastVLine(int16_t x, int16_t y, int16_t h, uint16_t color),
-      drawFastHLine(int16_t x, int16_t y, int16_t w, uint16_t color),
-      fillRect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t color),
-      fillScreen(uint16_t color),
-      // Optional and probably not necessary to change
-      drawLine(int16_t x0, int16_t y0, int16_t x1, int16_t y1, uint16_t color),
-      drawRect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t color);
+  virtual void drawFastVLine(int16_t x, int16_t y, int16_t h, uint16_t color);
+  virtual void drawFastHLine(int16_t x, int16_t y, int16_t w, uint16_t color);
+  virtual void fillRect(int16_t x, int16_t y, int16_t w, int16_t h,
+                        uint16_t color);
+  virtual void fillScreen(uint16_t color);
+  // Optional and probably not necessary to change
+  virtual void drawLine(int16_t x0, int16_t y0, int16_t x1, int16_t y1,
+                        uint16_t color);
+  virtual void drawRect(int16_t x, int16_t y, int16_t w, int16_t h,
+                        uint16_t color);
 
   // These exist only with Adafruit_GFX (no subclass overrides)
-  void drawCircle(int16_t x0, int16_t y0, int16_t r, uint16_t color),
-      drawCircleHelper(int16_t x0, int16_t y0, int16_t r, uint8_t cornername,
-                       uint16_t color),
-      fillCircle(int16_t x0, int16_t y0, int16_t r, uint16_t color),
-      fillCircleHelper(int16_t x0, int16_t y0, int16_t r, uint8_t cornername,
-                       int16_t delta, uint16_t color),
-      drawTriangle(int16_t x0, int16_t y0, int16_t x1, int16_t y1, int16_t x2,
-                   int16_t y2, uint16_t color),
-      fillTriangle(int16_t x0, int16_t y0, int16_t x1, int16_t y1, int16_t x2,
-                   int16_t y2, uint16_t color),
-      drawRoundRect(int16_t x0, int16_t y0, int16_t w, int16_t h,
-                    int16_t radius, uint16_t color),
-      fillRoundRect(int16_t x0, int16_t y0, int16_t w, int16_t h,
-                    int16_t radius, uint16_t color),
-      drawBitmap(int16_t x, int16_t y, const uint8_t bitmap[], int16_t w,
-                 int16_t h, uint16_t color),
-      drawBitmap(int16_t x, int16_t y, const uint8_t bitmap[], int16_t w,
-                 int16_t h, uint16_t color, uint16_t bg),
-      drawBitmap(int16_t x, int16_t y, uint8_t *bitmap, int16_t w, int16_t h,
-                 uint16_t color),
-      drawBitmap(int16_t x, int16_t y, uint8_t *bitmap, int16_t w, int16_t h,
-                 uint16_t color, uint16_t bg),
-      drawXBitmap(int16_t x, int16_t y, const uint8_t bitmap[], int16_t w,
-                  int16_t h, uint16_t color),
-      drawGrayscaleBitmap(int16_t x, int16_t y, const uint8_t bitmap[],
-                          int16_t w, int16_t h),
-      drawGrayscaleBitmap(int16_t x, int16_t y, uint8_t *bitmap, int16_t w,
-                          int16_t h),
-      drawGrayscaleBitmap(int16_t x, int16_t y, const uint8_t bitmap[],
-                          const uint8_t mask[], int16_t w, int16_t h),
-      drawGrayscaleBitmap(int16_t x, int16_t y, uint8_t *bitmap, uint8_t *mask,
-                          int16_t w, int16_t h),
-      drawRGBBitmap(int16_t x, int16_t y, const uint16_t bitmap[], int16_t w,
-                    int16_t h),
-      drawRGBBitmap(int16_t x, int16_t y, uint16_t *bitmap, int16_t w,
-                    int16_t h),
-      drawRGBBitmap(int16_t x, int16_t y, const uint16_t bitmap[],
-                    const uint8_t mask[], int16_t w, int16_t h),
-      drawRGBBitmap(int16_t x, int16_t y, uint16_t *bitmap, uint8_t *mask,
-                    int16_t w, int16_t h),
-      drawChar(int16_t x, int16_t y, unsigned char c, uint16_t color,
-               uint16_t bg, uint8_t size),
-      drawChar(int16_t x, int16_t y, unsigned char c, uint16_t color,
-               uint16_t bg, uint8_t size_x, uint8_t size_y),
-      getTextBounds(const char *string, int16_t x, int16_t y, int16_t *x1,
-                    int16_t *y1, uint16_t *w, uint16_t *h),
-      getTextBounds(const __FlashStringHelper *s, int16_t x, int16_t y,
-                    int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h),
-      getTextBounds(const String &str, int16_t x, int16_t y, int16_t *x1,
-                    int16_t *y1, uint16_t *w, uint16_t *h),
-      setTextSize(uint8_t s), setTextSize(uint8_t sx, uint8_t sy),
-      setFont(const GFXfont *f = NULL);
+  void drawCircle(int16_t x0, int16_t y0, int16_t r, uint16_t color);
+  void drawCircleHelper(int16_t x0, int16_t y0, int16_t r, uint8_t cornername,
+                        uint16_t color);
+  void fillCircle(int16_t x0, int16_t y0, int16_t r, uint16_t color);
+  void fillCircleHelper(int16_t x0, int16_t y0, int16_t r, uint8_t cornername,
+                        int16_t delta, uint16_t color);
+  void drawTriangle(int16_t x0, int16_t y0, int16_t x1, int16_t y1, int16_t x2,
+                    int16_t y2, uint16_t color);
+  void fillTriangle(int16_t x0, int16_t y0, int16_t x1, int16_t y1, int16_t x2,
+                    int16_t y2, uint16_t color);
+  void drawRoundRect(int16_t x0, int16_t y0, int16_t w, int16_t h,
+                     int16_t radius, uint16_t color);
+  void fillRoundRect(int16_t x0, int16_t y0, int16_t w, int16_t h,
+                     int16_t radius, uint16_t color);
+  void drawBitmap(int16_t x, int16_t y, const uint8_t bitmap[], int16_t w,
+                  int16_t h, uint16_t color);
+  void drawBitmap(int16_t x, int16_t y, const uint8_t bitmap[], int16_t w,
+                  int16_t h, uint16_t color, uint16_t bg);
+  void drawBitmap(int16_t x, int16_t y, uint8_t *bitmap, int16_t w, int16_t h,
+                  uint16_t color);
+  void drawBitmap(int16_t x, int16_t y, uint8_t *bitmap, int16_t w, int16_t h,
+                  uint16_t color, uint16_t bg);
+  void drawXBitmap(int16_t x, int16_t y, const uint8_t bitmap[], int16_t w,
+                   int16_t h, uint16_t color);
+  void drawGrayscaleBitmap(int16_t x, int16_t y, const uint8_t bitmap[],
+                           int16_t w, int16_t h);
+  void drawGrayscaleBitmap(int16_t x, int16_t y, uint8_t *bitmap, int16_t w,
+                           int16_t h);
+  void drawGrayscaleBitmap(int16_t x, int16_t y, const uint8_t bitmap[],
+                           const uint8_t mask[], int16_t w, int16_t h);
+  void drawGrayscaleBitmap(int16_t x, int16_t y, uint8_t *bitmap, uint8_t *mask,
+                           int16_t w, int16_t h);
+  void drawRGBBitmap(int16_t x, int16_t y, const uint16_t bitmap[], int16_t w,
+                     int16_t h);
+  void drawRGBBitmap(int16_t x, int16_t y, uint16_t *bitmap, int16_t w,
+                     int16_t h);
+  void drawRGBBitmap(int16_t x, int16_t y, const uint16_t bitmap[],
+                     const uint8_t mask[], int16_t w, int16_t h);
+  void drawRGBBitmap(int16_t x, int16_t y, uint16_t *bitmap, uint8_t *mask,
+                     int16_t w, int16_t h);
+  void drawChar(int16_t x, int16_t y, unsigned char c, uint16_t color,
+                uint16_t bg, uint8_t size);
+  void drawChar(int16_t x, int16_t y, unsigned char c, uint16_t color,
+                uint16_t bg, uint8_t size_x, uint8_t size_y);
+  void getTextBounds(const char *string, int16_t x, int16_t y, int16_t *x1,
+                     int16_t *y1, uint16_t *w, uint16_t *h);
+  void getTextBounds(const __FlashStringHelper *s, int16_t x, int16_t y,
+                     int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h);
+  void getTextBounds(const String &str, int16_t x, int16_t y, int16_t *x1,
+                     int16_t *y1, uint16_t *w, uint16_t *h);
+  void setTextSize(uint8_t s), setTextSize(uint8_t sx, uint8_t sy);
+  void setFont(const GFXfont *f = NULL);
 
   /**********************************************************************/
   /*!
@@ -222,20 +228,20 @@ public:
 protected:
   void charBounds(char c, int16_t *x, int16_t *y, int16_t *minx, int16_t *miny,
                   int16_t *maxx, int16_t *maxy);
-  int16_t WIDTH,      ///< This is the 'raw' display width - never changes
-      HEIGHT;         ///< This is the 'raw' display height - never changes
-  int16_t _width,     ///< Display width as modified by current rotation
-      _height,        ///< Display height as modified by current rotation
-      cursor_x,       ///< x location to start print()ing text
-      cursor_y;       ///< y location to start print()ing text
-  uint16_t textcolor, ///< 16-bit background color for print()
-      textbgcolor;    ///< 16-bit text color for print()
-  uint8_t textsize_x, ///< Desired magnification in X-axis of text to print()
-      textsize_y,     ///< Desired magnification in Y-axis of text to print()
-      rotation;       ///< Display rotation (0 thru 3)
-  boolean wrap,       ///< If set, 'wrap' text at right edge of display
-      _cp437;         ///< If set, use correct CP437 charset (default is off)
-  GFXfont *gfxFont;   ///< Pointer to special font
+  int16_t WIDTH;        ///< This is the 'raw' display width - never changes
+  int16_t HEIGHT;       ///< This is the 'raw' display height - never changes
+  int16_t _width;       ///< Display width as modified by current rotation
+  int16_t _height;      ///< Display height as modified by current rotation
+  int16_t cursor_x;     ///< x location to start print()ing text
+  int16_t cursor_y;     ///< y location to start print()ing text
+  uint16_t textcolor;   ///< 16-bit background color for print()
+  uint16_t textbgcolor; ///< 16-bit text color for print()
+  uint8_t textsize_x;   ///< Desired magnification in X-axis of text to print()
+  uint8_t textsize_y;   ///< Desired magnification in Y-axis of text to print()
+  uint8_t rotation;     ///< Display rotation (0 thru 3)
+  boolean wrap;         ///< If set, 'wrap' text at right edge of display
+  boolean _cp437;       ///< If set, use correct CP437 charset (default is off)
+  GFXfont *gfxFont;     ///< Pointer to special font
 };
 
 /// A simple drawn button UI element
@@ -301,8 +307,8 @@ class GFXcanvas1 : public Adafruit_GFX {
 public:
   GFXcanvas1(uint16_t w, uint16_t h);
   ~GFXcanvas1(void);
-  void drawPixel(int16_t x, int16_t y, uint16_t color),
-      fillScreen(uint16_t color);
+  void drawPixel(int16_t x, int16_t y, uint16_t color);
+  void fillScreen(uint16_t color);
   /**********************************************************************/
   /*!
     @brief    Get a pointer to the internal buffer memory
@@ -320,9 +326,9 @@ class GFXcanvas8 : public Adafruit_GFX {
 public:
   GFXcanvas8(uint16_t w, uint16_t h);
   ~GFXcanvas8(void);
-  void drawPixel(int16_t x, int16_t y, uint16_t color),
-      fillScreen(uint16_t color),
-      writeFastHLine(int16_t x, int16_t y, int16_t w, uint16_t color);
+  void drawPixel(int16_t x, int16_t y, uint16_t color);
+  void fillScreen(uint16_t color);
+  void writeFastHLine(int16_t x, int16_t y, int16_t w, uint16_t color);
   /**********************************************************************/
   /*!
    @brief    Get a pointer to the internal buffer memory
@@ -340,8 +346,8 @@ class GFXcanvas16 : public Adafruit_GFX {
 public:
   GFXcanvas16(uint16_t w, uint16_t h);
   ~GFXcanvas16(void);
-  void drawPixel(int16_t x, int16_t y, uint16_t color),
-      fillScreen(uint16_t color), byteSwap(void);
+  void drawPixel(int16_t x, int16_t y, uint16_t color);
+  void fillScreen(uint16_t color), byteSwap(void);
   /**********************************************************************/
   /*!
     @brief    Get a pointer to the internal buffer memory

--- a/Adafruit_GFX.h
+++ b/Adafruit_GFX.h
@@ -114,7 +114,8 @@ public:
                      int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h);
   void getTextBounds(const String &str, int16_t x, int16_t y, int16_t *x1,
                      int16_t *y1, uint16_t *w, uint16_t *h);
-  void setTextSize(uint8_t s), setTextSize(uint8_t sx, uint8_t sy);
+  void setTextSize(uint8_t s);
+  void setTextSize(uint8_t sx, uint8_t sy);
   void setFont(const GFXfont *f = NULL);
 
   /**********************************************************************/
@@ -347,7 +348,8 @@ public:
   GFXcanvas16(uint16_t w, uint16_t h);
   ~GFXcanvas16(void);
   void drawPixel(int16_t x, int16_t y, uint16_t color);
-  void fillScreen(uint16_t color), byteSwap(void);
+  void fillScreen(uint16_t color);
+  void byteSwap(void);
   /**********************************************************************/
   /*!
     @brief    Get a pointer to the internal buffer memory


### PR DESCRIPTION
No technical change. Just separating the multi-member decls into single-member decls.

This helps with clang-format, and conforms with C++ convention. It's hard to scroll 52 lines up from `setFont` to see its associated `virtual void`. Also allows functions to be arranged by functional group rather than their type, and gives a better place to hang per-member documentation.

Fix up the `drawPixel` Doxygen comment, which seems to have been ruined by a previous clang-format run or something.