### PR TITLE
Update MonoOLED i2c constructor to match var def order

### DIFF
--- a/Adafruit_MonoOLED.cpp
+++ b/Adafruit_MonoOLED.cpp
@@ -60,8 +60,8 @@
 Adafruit_MonoOLED::Adafruit_MonoOLED(uint16_t w, uint16_t h, TwoWire *twi,
                                      int8_t rst_pin, uint32_t clkDuring,
                                      uint32_t clkAfter)
-    : Adafruit_GFX(w, h), buffer(NULL), dcPin(-1), csPin(-1), rstPin(rst_pin),
-      i2c_preclk(clkDuring), i2c_postclk(clkAfter) {
+    : Adafruit_GFX(w, h), i2c_preclk(clkDuring), i2c_postclk(clkAfter),
+      buffer(NULL), dcPin(-1), csPin(-1), rstPin(rst_pin) {
   i2c_dev = NULL;
   _theWire = twi;
 }


### PR DESCRIPTION
This updates the initialization of variables in the I2C Adafruit_MonoOLED constructor. The call signature and variable definitions are unchanged. This fixes a `reorder` compiler warning due to member initialization not matching member declaration. This becomes a compiler error with the [standard ESP32 platform.txt](https://github.com/espressif/arduino-esp32/blob/49b76649f13acdb8abaf795015d2740bc5f6b340/platform.txt#L21) with warning level "All".

The mock_ili9341 example compiles with no new warnings with `compiler.warning_level=all` in the latest Arduino IDE. This was tested for Adafruit Circuit Playground, ESP32, and Arduino Due.