### PR TITLE
Allow changing the SPI mode after initialization

### DIFF
--- a/Adafruit_SPITFT.cpp
+++ b/Adafruit_SPITFT.cpp
@@ -890,16 +890,24 @@ void Adafruit_SPITFT::initSPI(uint32_t freq, uint8_t spiMode) {
 }
 
 /*!
-    @brief  Allow changing the SPI clock speed after initialization
-    @param  freq Desired frequency of SPI clock, may not be the
-    end frequency you get based on what the chip can do!
+    @brief  Allow changing the SPI clock speed and SPI mode after initialization
+    @param  freq     Desired frequency of SPI clock, may not be the end
+                     frequency you get based on what the chip can do!
+    @param  spiMode  SPI mode when using hardware SPI (optional, -1 if unused).
+                     MUST be one of the values SPI_MODE0, SPI_MODE1, SPI_MODE2
+                     or SPI_MODE3 defined in SPI.h. Do NOT attempt to pass '0'
+                     for SPI_MODE0 and so forth...the values are NOT the same!
+                     Use ONLY the defines! (Pity it's not an enum.)
 */
-void Adafruit_SPITFT::setSPISpeed(uint32_t freq) {
+void Adafruit_SPITFT::setSPISpeed(uint32_t freq, uint8_t spiMode) {
 #if defined(SPI_HAS_TRANSACTION)
-  hwspi.settings = SPISettings(freq, MSBFIRST, hwspi._mode);
+  if (spiMode == -1)
+    spiMode = hwspi._mode;
+  hwspi.settings = SPISettings(freq, MSBFIRST, spiMode);
 #else
   hwspi._freq = freq; // Save freq value for later
 #endif
+  hwspi._mode = spiMode; // Save spiMode value for later
 }
 
 /*!

--- a/Adafruit_SPITFT.h
+++ b/Adafruit_SPITFT.h
@@ -189,7 +189,7 @@ public:
   // 1 for SPI_MODE1, etc...use ONLY the SPI_MODEn defines! Only!
   // Name is outdated (interface may be parallel) but for compatibility:
   void initSPI(uint32_t freq = 0, uint8_t spiMode = SPI_MODE0);
-  void setSPISpeed(uint32_t freq);
+  void setSPISpeed(uint32_t freq, uint8_t spiMode = -1);
   // Chip select and/or hardware SPI transaction start as needed:
   void startWrite(void);
   // Chip deselect and/or hardware SPI transaction end as needed:


### PR DESCRIPTION
This change allows for the SPI mode to be changed after initialization. It is done via the setSPISpeed() call, as that is the simplest way to do this without impacting the API.

A separate setSPIMode() function is not possible, as no frequency is known at that point (not saved anywhere). An alternative option could be introducing a new setSPISpeedAndMode(uint32_t freq, uint8_t spiMode) call, but adding spiMode to the speed call seems simpler.

This enhancement is necessary for the Sony Spresense board, as this needs SPI_MODE3 to communicate with the ILI9341 screen.