### PR TITLE
fontconvert.c missing a #include

### DIFF
--- a/fontconvert/fontconvert.c
+++ b/fontconvert/fontconvert.c
@@ -23,6 +23,7 @@ See notes at end for glyph nomenclature & other tidbits.
 #include <stdint.h>
 #include <stdio.h>
 #include FT_GLYPH_H
+#include FT_MODULE_H
 #include FT_TRUETYPE_DRIVER_H
 #include "../gfxfont.h" // Adafruit_GFX font structures
 


### PR DESCRIPTION
`fontconvert/fontconvert.c` was missing an include of `FT_MODULE_H`
Fixes Issue #273
