### PR TITLE
Add const specifier for strings

### DIFF
--- a/Adafruit_GFX.cpp
+++ b/Adafruit_GFX.cpp
@@ -1561,7 +1561,7 @@ Adafruit_GFX_Button::Adafruit_GFX_Button(void) { _gfx = 0; }
 void Adafruit_GFX_Button::initButton(Adafruit_GFX *gfx, int16_t x, int16_t y,
                                      uint16_t w, uint16_t h, uint16_t outline,
                                      uint16_t fill, uint16_t textcolor,
-                                     char *label, uint8_t textsize) {
+                                     const char *label, uint8_t textsize) {
   // Tweak arguments and pass to the newer initButtonUL() function...
   initButtonUL(gfx, x - (w / 2), y - (h / 2), w, h, outline, fill, textcolor,
                label, textsize);
@@ -1587,7 +1587,7 @@ void Adafruit_GFX_Button::initButton(Adafruit_GFX *gfx, int16_t x, int16_t y,
 void Adafruit_GFX_Button::initButton(Adafruit_GFX *gfx, int16_t x, int16_t y,
                                      uint16_t w, uint16_t h, uint16_t outline,
                                      uint16_t fill, uint16_t textcolor,
-                                     char *label, uint8_t textsize_x,
+                                     const char *label, uint8_t textsize_x,
                                      uint8_t textsize_y) {
   // Tweak arguments and pass to the newer initButtonUL() function...
   initButtonUL(gfx, x - (w / 2), y - (h / 2), w, h, outline, fill, textcolor,
@@ -1613,7 +1613,7 @@ void Adafruit_GFX_Button::initButton(Adafruit_GFX *gfx, int16_t x, int16_t y,
 void Adafruit_GFX_Button::initButtonUL(Adafruit_GFX *gfx, int16_t x1,
                                        int16_t y1, uint16_t w, uint16_t h,
                                        uint16_t outline, uint16_t fill,
-                                       uint16_t textcolor, char *label,
+                                       uint16_t textcolor, const char *label,
                                        uint8_t textsize) {
   initButtonUL(gfx, x1, y1, w, h, outline, fill, textcolor, label, textsize,
                textsize);
@@ -1639,7 +1639,7 @@ void Adafruit_GFX_Button::initButtonUL(Adafruit_GFX *gfx, int16_t x1,
 void Adafruit_GFX_Button::initButtonUL(Adafruit_GFX *gfx, int16_t x1,
                                        int16_t y1, uint16_t w, uint16_t h,
                                        uint16_t outline, uint16_t fill,
-                                       uint16_t textcolor, char *label,
+                                       uint16_t textcolor, const char *label,
                                        uint8_t textsize_x, uint8_t textsize_y) {
   _x1 = x1;
   _y1 = y1;

--- a/Adafruit_GFX.h
+++ b/Adafruit_GFX.h
@@ -253,18 +253,18 @@ public:
   // "Classic" initButton() uses center & size
   void initButton(Adafruit_GFX *gfx, int16_t x, int16_t y, uint16_t w,
                   uint16_t h, uint16_t outline, uint16_t fill,
-                  uint16_t textcolor, char *label, uint8_t textsize);
+                  uint16_t textcolor, const char *label, uint8_t textsize);
   void initButton(Adafruit_GFX *gfx, int16_t x, int16_t y, uint16_t w,
                   uint16_t h, uint16_t outline, uint16_t fill,
-                  uint16_t textcolor, char *label, uint8_t textsize_x,
+                  uint16_t textcolor, const char *label, uint8_t textsize_x,
                   uint8_t textsize_y);
   // New/alt initButton() uses upper-left corner & size
   void initButtonUL(Adafruit_GFX *gfx, int16_t x1, int16_t y1, uint16_t w,
                     uint16_t h, uint16_t outline, uint16_t fill,
-                    uint16_t textcolor, char *label, uint8_t textsize);
+                    uint16_t textcolor, const char *label, uint8_t textsize);
   void initButtonUL(Adafruit_GFX *gfx, int16_t x1, int16_t y1, uint16_t w,
                     uint16_t h, uint16_t outline, uint16_t fill,
-                    uint16_t textcolor, char *label, uint8_t textsize_x,
+                    uint16_t textcolor, const char *label, uint8_t textsize_x,
                     uint8_t textsize_y);
   void drawButton(boolean inverted = false);
   boolean contains(int16_t x, int16_t y);


### PR DESCRIPTION
Without the `const` specifier methods would be able to modify immutable strings. 
-  it fixes the compiler warning: 
`warning: deprecated conversion from string constant to 'char*' [-Wwrite-strings]`
-  prevents illegal operations on the passed `char*` strings.

I did not test the changes.
I assume that right now the change is just relevant for the compiler, because the code currently does not illegally modify the passed `char *`. (Although in the future it could come in handy to receive a compiler message upon violations.)