### PR TITLE
Change boolean to bool

### DIFF
--- a/Adafruit_GFX.cpp
+++ b/Adafruit_GFX.cpp
@@ -1529,7 +1529,7 @@ void Adafruit_GFX::getTextBounds(const __FlashStringHelper *str, int16_t x,
     @param   i  True if you want to invert, false to make 'normal'
 */
 /**************************************************************************/
-void Adafruit_GFX::invertDisplay(boolean i) {
+void Adafruit_GFX::invertDisplay(bool i) {
   // Do nothing, must be subclassed if supported by hardware
 }
 
@@ -1661,7 +1661,7 @@ void Adafruit_GFX_Button::initButtonUL(Adafruit_GFX *gfx, int16_t x1,
    'pressed'
 */
 /**************************************************************************/
-void Adafruit_GFX_Button::drawButton(boolean inverted) {
+void Adafruit_GFX_Button::drawButton(bool inverted) {
   uint16_t fill, outline, text;
 
   if (!inverted) {
@@ -1694,7 +1694,7 @@ void Adafruit_GFX_Button::drawButton(boolean inverted) {
     @returns  True if within button graphics outline
 */
 /**************************************************************************/
-boolean Adafruit_GFX_Button::contains(int16_t x, int16_t y) {
+bool Adafruit_GFX_Button::contains(int16_t x, int16_t y) {
   return ((x >= _x1) && (x < (int16_t)(_x1 + _w)) && (y >= _y1) &&
           (y < (int16_t)(_y1 + _h)));
 }
@@ -1705,7 +1705,7 @@ boolean Adafruit_GFX_Button::contains(int16_t x, int16_t y) {
    @returns  True if was not-pressed before, now is.
 */
 /**************************************************************************/
-boolean Adafruit_GFX_Button::justPressed() { return (currstate && !laststate); }
+bool Adafruit_GFX_Button::justPressed() { return (currstate && !laststate); }
 
 /**************************************************************************/
 /*!
@@ -1713,7 +1713,7 @@ boolean Adafruit_GFX_Button::justPressed() { return (currstate && !laststate); }
    @returns  True if was pressed before, now is not.
 */
 /**************************************************************************/
-boolean Adafruit_GFX_Button::justReleased() {
+bool Adafruit_GFX_Button::justReleased() {
   return (!currstate && laststate);
 }
 

--- a/Adafruit_GFX.cpp
+++ b/Adafruit_GFX.cpp
@@ -1713,9 +1713,7 @@ bool Adafruit_GFX_Button::justPressed() { return (currstate && !laststate); }
    @returns  True if was pressed before, now is not.
 */
 /**************************************************************************/
-bool Adafruit_GFX_Button::justReleased() {
-  return (!currstate && laststate);
-}
+bool Adafruit_GFX_Button::justReleased() { return (!currstate && laststate); }
 
 // -------------------------------------------------------------------------
 

--- a/Adafruit_GFX.h
+++ b/Adafruit_GFX.h
@@ -45,7 +45,7 @@ public:
   // These MAY be overridden by the subclass to provide device-specific
   // optimized code.  Otherwise 'generic' versions are used.
   virtual void setRotation(uint8_t r);
-  virtual void invertDisplay(boolean i);
+  virtual void invertDisplay(bool i);
 
   // BASIC DRAW API
   // These MAY be overridden by the subclass to provide device-specific
@@ -159,7 +159,7 @@ public:
   @param  w  true for wrapping, false for clipping
   */
   /**********************************************************************/
-  void setTextWrap(boolean w) { wrap = w; }
+  void setTextWrap(bool w) { wrap = w; }
 
   /**********************************************************************/
   /*!
@@ -175,7 +175,7 @@ public:
     @param  x  true = enable (new behavior), false = disable (old behavior)
   */
   /**********************************************************************/
-  void cp437(boolean x = true) { _cp437 = x; }
+  void cp437(bool x = true) { _cp437 = x; }
 
   using Print::write;
 #if ARDUINO >= 100
@@ -240,8 +240,8 @@ protected:
   uint8_t textsize_x;   ///< Desired magnification in X-axis of text to print()
   uint8_t textsize_y;   ///< Desired magnification in Y-axis of text to print()
   uint8_t rotation;     ///< Display rotation (0 thru 3)
-  boolean wrap;         ///< If set, 'wrap' text at right edge of display
-  boolean _cp437;       ///< If set, use correct CP437 charset (default is off)
+  bool wrap;         ///< If set, 'wrap' text at right edge of display
+  bool _cp437;       ///< If set, use correct CP437 charset (default is off)
   GFXfont *gfxFont;     ///< Pointer to special font
 };
 
@@ -266,8 +266,8 @@ public:
                     uint16_t h, uint16_t outline, uint16_t fill,
                     uint16_t textcolor, char *label, uint8_t textsize_x,
                     uint8_t textsize_y);
-  void drawButton(boolean inverted = false);
-  boolean contains(int16_t x, int16_t y);
+  void drawButton(bool inverted = false);
+  bool contains(int16_t x, int16_t y);
 
   /**********************************************************************/
   /*!
@@ -275,13 +275,13 @@ public:
     @param    p  True for pressed, false for not.
   */
   /**********************************************************************/
-  void press(boolean p) {
+  void press(bool p) {
     laststate = currstate;
     currstate = p;
   }
 
-  boolean justPressed();
-  boolean justReleased();
+  bool justPressed();
+  bool justReleased();
 
   /**********************************************************************/
   /*!
@@ -289,7 +289,7 @@ public:
     @returns  True if pressed
   */
   /**********************************************************************/
-  boolean isPressed(void) { return currstate; };
+  bool isPressed(void) { return currstate; };
 
 private:
   Adafruit_GFX *_gfx;
@@ -300,7 +300,7 @@ private:
   uint16_t _outlinecolor, _fillcolor, _textcolor;
   char _label[10];
 
-  boolean currstate, laststate;
+  bool currstate, laststate;
 };
 
 /// A GFX 1-bit canvas context for graphics

--- a/Adafruit_GFX.h
+++ b/Adafruit_GFX.h
@@ -240,8 +240,8 @@ protected:
   uint8_t textsize_x;   ///< Desired magnification in X-axis of text to print()
   uint8_t textsize_y;   ///< Desired magnification in Y-axis of text to print()
   uint8_t rotation;     ///< Display rotation (0 thru 3)
-  bool wrap;         ///< If set, 'wrap' text at right edge of display
-  bool _cp437;       ///< If set, use correct CP437 charset (default is off)
+  bool wrap;            ///< If set, 'wrap' text at right edge of display
+  bool _cp437;          ///< If set, use correct CP437 charset (default is off)
   GFXfont *gfxFont;     ///< Pointer to special font
 };
 

--- a/Adafruit_MonoOLED.cpp
+++ b/Adafruit_MonoOLED.cpp
@@ -213,7 +213,7 @@ bool Adafruit_MonoOLED::oled_commandList(const uint8_t *c, uint8_t n) {
             proceeding.
     @note   MUST call this function before any drawing or updates!
 */
-bool Adafruit_MonoOLED::_init(uint8_t addr, boolean reset) {
+bool Adafruit_MonoOLED::_init(uint8_t addr, bool reset) {
 
   // attempt to malloc the bitmap framebuffer
   if ((!buffer) && !(buffer = (uint8_t *)malloc(WIDTH * ((HEIGHT + 7) / 8)))) {
@@ -339,7 +339,7 @@ void Adafruit_MonoOLED::clearDisplay(void) {
     @note   Reads from buffer contents; may not reflect current contents of
             screen if display() has not been called.
 */
-boolean Adafruit_MonoOLED::getPixel(int16_t x, int16_t y) {
+bool Adafruit_MonoOLED::getPixel(int16_t x, int16_t y) {
   if ((x >= 0) && (x < width()) && (y >= 0) && (y < height())) {
     // Pixel is in-bounds. Rotate coordinates if needed.
     switch (getRotation()) {
@@ -383,7 +383,7 @@ uint8_t *Adafruit_MonoOLED::getBuffer(void) { return buffer; }
             enabled, drawing MONOOLED_BLACK (value 0) pixels will actually draw
    white, MONOOLED_WHITE (value 1) will draw black.
 */
-void Adafruit_MonoOLED::invertDisplay(boolean i) {
+void Adafruit_MonoOLED::invertDisplay(bool i) {
   oled_command(i ? MONOOLED_INVERTDISPLAY : MONOOLED_NORMALDISPLAY);
 }
 

--- a/Adafruit_MonoOLED.h
+++ b/Adafruit_MonoOLED.h
@@ -66,17 +66,17 @@ public:
    **/
   virtual void display(void) = 0;
   void clearDisplay(void);
-  void invertDisplay(boolean i);
+  void invertDisplay(bool i);
   void setContrast(uint8_t contrastlevel);
   void drawPixel(int16_t x, int16_t y, uint16_t color);
-  boolean getPixel(int16_t x, int16_t y);
+  bool getPixel(int16_t x, int16_t y);
   uint8_t *getBuffer(void);
 
   void oled_command(uint8_t c);
   bool oled_commandList(const uint8_t *c, uint8_t n);
 
 protected:
-  bool _init(uint8_t i2caddr = 0x3C, boolean reset = true);
+  bool _init(uint8_t i2caddr = 0x3C, bool reset = true);
 
   Adafruit_SPIDevice *spi_dev = NULL; ///< The SPI interface BusIO device
   Adafruit_I2CDevice *i2c_dev = NULL; ///< The I2C interface BusIO device


### PR DESCRIPTION
This avoids compiler warnings such as:

    In file included from /home/ed/git/dryer-arduino/ui/src/graphicstest.ino:18:
    .pio/libdeps/nucleo_f446re/Adafruit GFX Library_ID13/Adafruit_GFX.h:48:39: warning: 'boolean' is deprecated [-Wdeprecated-declarations]
       48 |   virtual void invertDisplay(boolean i);
          |                                       ^
    In file included from /home/ed/.platformio/packages/framework-arduinoststm32/cores/arduino/wiring.h:34,
                     from /home/ed/.platformio/packages/framework-arduinoststm32/cores/arduino/Arduino.h:32,
                     from /tmp/tmpvslwxjr7:1:
    /home/ed/.platformio/packages/framework-arduinoststm32/cores/arduino/wiring_constants.h:110:14: note: declared here