### PR TITLE
add support for LGT8F cpu

### DIFF
--- a/Adafruit_SPITFT.cpp
+++ b/Adafruit_SPITFT.cpp
@@ -39,6 +39,8 @@
 #if defined(__AVR_XMEGA__) // only tested with __AVR_ATmega4809__
 #define AVR_WRITESPI(x)                                                        \
   for (SPI0_DATA = (x); (!(SPI0_INTFLAGS & _BV(SPI_IF_bp)));)
+#elif defined(__LGT8F__)
+#define AVR_WRITESPI(x) SPDR = (x);asm volatile("nop");while((SPFR & _BV(RDEMPT)));SPFR = _BV(RDEMPT) | _BV(WREMPT)
 #else
 #define AVR_WRITESPI(x) for (SPDR = (x); (!(SPSR & _BV(SPIF)));)
 #endif

--- a/Adafruit_SPITFT.cpp
+++ b/Adafruit_SPITFT.cpp
@@ -40,7 +40,12 @@
 #define AVR_WRITESPI(x)                                                        \
   for (SPI0_DATA = (x); (!(SPI0_INTFLAGS & _BV(SPI_IF_bp)));)
 #elif defined(__LGT8F__)
-#define AVR_WRITESPI(x) SPDR = (x);asm volatile("nop");while((SPFR & _BV(RDEMPT)));SPFR = _BV(RDEMPT) | _BV(WREMPT)
+#define AVR_WRITESPI(x)                                                        \
+  SPDR = (x);                                                                  \
+  asm volatile("nop");                                                         \
+  while ((SPFR & _BV(RDEMPT)))                                                 \
+    ;                                                                          \
+  SPFR = _BV(RDEMPT) | _BV(WREMPT)
 #else
 #define AVR_WRITESPI(x) for (SPDR = (x); (!(SPSR & _BV(SPIF)));)
 #endif

--- a/Adafruit_SPITFT.h
+++ b/Adafruit_SPITFT.h
@@ -65,7 +65,7 @@ typedef uint32_t ADAGFX_PORT_t; ///< PORT values are 32-bit
 #endif                                     // end !ARM
 typedef volatile ADAGFX_PORT_t *PORTreg_t; ///< PORT register type
 
-#if defined(__AVR__)
+#if defined(__AVR__) && !defined(__LGT8F__)
 #define DEFAULT_SPI_FREQ 8000000L ///< Hardware SPI default speed
 #else
 #define DEFAULT_SPI_FREQ 16000000L ///< Hardware SPI default speed


### PR DESCRIPTION
Add support for the LGT8F-series of CPUs, which behave different from original Atmega due to 4 byte SPI buffer.
Before, SPI does not work, because DC changes level in the middle of a byte - the macro did not know of the SPI buffer and instantly returned instead of waiting for the full sent byte.

For minimal changes, just to make it work, I only changed the AVR_WRITESPI define.
I did not implement the 4 byte buffering (which would make the 16-bit-writes a little bit faster)

As a side note, I also changed the default SPI frequency to 16MHz (at 32MHz CPU speed) for this CPU.

Background:
The LGT8F-Series is a cheaper Atmega328D/P "clone" with more features and faster core, running up to 32MHz.
It's not unusual to get Arduinos with this chip if you buy some Nano or Pro. 