### PR TITLE
Make Destructors virtual in GFXcanvas* classes

### DIFF
--- a/Adafruit_GFX.h
+++ b/Adafruit_GFX.h
@@ -307,7 +307,7 @@ private:
 class GFXcanvas1 : public Adafruit_GFX {
 public:
   GFXcanvas1(uint16_t w, uint16_t h);
-  ~GFXcanvas1(void);
+  virtual ~GFXcanvas1(void);
   void drawPixel(int16_t x, int16_t y, uint16_t color);
   void fillScreen(uint16_t color);
   bool getPixel(int16_t x, int16_t y) const;
@@ -335,7 +335,7 @@ private:
 class GFXcanvas8 : public Adafruit_GFX {
 public:
   GFXcanvas8(uint16_t w, uint16_t h);
-  ~GFXcanvas8(void);
+  virtual ~GFXcanvas8(void);
   void drawPixel(int16_t x, int16_t y, uint16_t color);
   void fillScreen(uint16_t color);
   void writeFastHLine(int16_t x, int16_t y, int16_t w, uint16_t color);
@@ -359,7 +359,7 @@ private:
 class GFXcanvas16 : public Adafruit_GFX {
 public:
   GFXcanvas16(uint16_t w, uint16_t h);
-  ~GFXcanvas16(void);
+  virtual ~GFXcanvas16(void);
   void drawPixel(int16_t x, int16_t y, uint16_t color);
   void fillScreen(uint16_t color);
   void byteSwap(void);


### PR DESCRIPTION
All this change does is make `virtual` the destructors declared in the `GFXcanvas*` classes. This is a simple fix. C++ class destructors should really be `virtual` to enable subclasses. The only reason why non-virtual class destructors should be used is if the class should never be inherited from. I am assuming it is valid for `GFXcanvas*` classes to be a base class (I can't imagine a reason why they shouldn't be base classes, but please inform me if there is). For people who do create a subclass from a `GFXcanvas*` class, a non-virtual destructor creates a really hard to discover bug (as I have learned). So, this change fixes the bugs that anybody who created a sub-class from a `GFXcanvas*` class is experiencing. Admittedly the bug is rarely expressed because most often in Arduino-style embedded programming objects don't get deleted. But, if you should ever need to delete an object derived from a class with a non-virtual destructor, the bug will manifest.