### PR TITLE
Fix GFXcanvas16::drawFastRawHLine

### DIFF
--- a/Adafruit_GFX.cpp
+++ b/Adafruit_GFX.cpp
@@ -2088,7 +2088,7 @@ void GFXcanvas1::drawFastRawHLine(int16_t x, int16_t y, int16_t w,
 
     if (lastByteBits > 0) {
       uint8_t lastByteBitMask = 0x00;
-      for (int8_t i = 0; i < lastByteBits; i++) {
+      for (size_t i = 0; i < lastByteBits; i++) {
 #ifdef __AVR__
         lastByteBitMask |= pgm_read_byte(&GFXsetBit[i]);
 #else
@@ -2662,8 +2662,8 @@ void GFXcanvas16::drawFastRawVLine(int16_t x, int16_t y, int16_t h,
 void GFXcanvas16::drawFastRawHLine(int16_t x, int16_t y, int16_t w,
                                    uint16_t color) {
   // x & y already in raw (rotation 0) coordinates, no need to transform.
-  size_t buffer_index = y * WIDTH + x;
-  for (int16_t i = buffer_index; i < buffer_index + w; i++) {
+  uint32_t buffer_index = y * WIDTH + x;
+  for (uint32_t i = buffer_index; i < buffer_index + w; i++) {
     buffer[i] = color;
   }
 }


### PR DESCRIPTION
This is a quick fix to fix functions like:
```
GFXcanvas16 *canvas = new GFXcanvas16 (240, 320)
canvas -> fillTriangle(0, 0, 239, 0, 120, 310, ILI9341_BLUE)
```
Could all on down to drawFastRawHLine and the
computerd buffer_index > 32767 which is the largest that could be held in int16_t.  So switched to uint32_t also converted the computed value to uint32_t as well as to remove compiler warning.

Removed another compiler warning as well.

This addresses the problem in
#325

