### PR TITLE
Fix -Wunused-parameter warnings

### DIFF
--- a/Adafruit_GFX.cpp
+++ b/Adafruit_GFX.cpp
@@ -1539,6 +1539,7 @@ void Adafruit_GFX::getTextBounds(const __FlashStringHelper *str, int16_t x,
 /**************************************************************************/
 void Adafruit_GFX::invertDisplay(bool i) {
   // Do nothing, must be subclassed if supported by hardware
+  (void)i; // disable -Wunused-parameter warning
 }
 
 /***************************************************************************/

--- a/Adafruit_SPITFT.cpp
+++ b/Adafruit_SPITFT.cpp
@@ -1984,6 +1984,7 @@ uint16_t Adafruit_SPITFT::readcommand16(uint16_t addr) {
   }
   return result;
 #else
+  (void)addr; // disable -Wunused-parameter warning
   return 0;
 #endif // end !USE_FAST_PINIO
 }
@@ -2171,6 +2172,8 @@ void Adafruit_SPITFT::write16(uint16_t w) {
 #if defined(USE_FAST_PINIO)
     if (tft8.wide)
       *(volatile uint16_t *)tft8.writePort = w;
+#else
+    (void)w; // disable -Wunused-parameter warning
 #endif
     TFT_WR_STROBE();
   }


### PR DESCRIPTION
Fixes the following compiler warnings from the Arduino IDE or Arduino CLI with warnings enabled. No functional change.

```
/home/brian/src/arduino/libraries/Adafruit-GFX-Library/Adafruit_GFX.cpp:1540:6: warning: unused parameter 'i' [-Wunused-parameter]
 void Adafruit_GFX::invertDisplay(bool i) {
      ^
/home/brian/src/arduino/libraries/Adafruit-GFX-Library/Adafruit_SPITFT.cpp:1964:10: warning: unused parameter 'addr' [-Wunused-parameter]
 uint16_t Adafruit_SPITFT::readcommand16(uint16_t addr) {
          ^
/home/brian/src/arduino/libraries/Adafruit-GFX-Library/Adafruit_SPITFT.cpp:2169:6: warning: unused parameter 'w' [-Wunused-parameter]
 void Adafruit_SPITFT::write16(uint16_t w) {
      ^
```