### PR TITLE
Add oled_commandAndArglist() method 

### DIFF
--- a/Adafruit_GrayOLED.cpp
+++ b/Adafruit_GrayOLED.cpp
@@ -198,6 +198,33 @@ bool Adafruit_GrayOLED::oled_commandList(const uint8_t *c, uint8_t n) {
   return true;
 }
 
+
+bool Adafruit_GrayOLED::oled_commandAndArgsList(const uint8_t *c, uint8_t n) {
+  uint8_t *end = (uint8_t *) c + n;
+
+  while (c < end) {
+    uint8_t command_len = *c;
+    ++c;
+
+    if (i2c_dev) {
+      uint8_t dc_byte = 0x00;
+      if (!i2c_dev->write((uint8_t *)c, command_len, true, &dc_byte, 1))
+        return false;
+    } else {
+      digitalWrite(dcPin, LOW);   // Command, D/C = 0
+      if (!spi_dev->write((uint8_t *) c, 1))
+        return false;
+      digitalWrite(dcPin, HIGH);  // Data, D/C = 1
+      if (!spi_dev->write((uint8_t *) (c+sizeof(uint8_t)), command_len-1))
+        return false;
+    }
+
+    c += command_len;
+  }
+
+  return true;
+}
+
 // ALLOCATE & INIT DISPLAY -------------------------------------------------
 
 /*!

--- a/Adafruit_GrayOLED.cpp
+++ b/Adafruit_GrayOLED.cpp
@@ -199,6 +199,16 @@ bool Adafruit_GrayOLED::oled_commandList(const uint8_t *c, uint8_t n) {
 }
 
 
+// Issue list of commands and args to GrayOLED
+/*!
+    @brief Issue list of commands and args to OLED, using I2C or hard/soft SPI as
+   needed.
+    @param c Pointer to the command and arg array, the array's elements should be
+             specified as (cmd0_len, cmd0_byte, cmd0_arg0, cmd0_arg1, .., cmd0_argn,
+             cmd1_len...)
+    @param n The number of bytes in the command and arg array
+    @returns True for success on ability to write the data in I2C.
+*/
 bool Adafruit_GrayOLED::oled_commandAndArgsList(const uint8_t *c, uint8_t n) {
   uint8_t *end = (uint8_t *) c + n;
 

--- a/Adafruit_GrayOLED.h
+++ b/Adafruit_GrayOLED.h
@@ -72,6 +72,7 @@ public:
 
   void oled_command(uint8_t c);
   bool oled_commandList(const uint8_t *c, uint8_t n);
+  bool oled_commandAndArgsList(const uint8_t *c, uint8_t n);
 
 protected:
   bool _init(uint8_t i2caddr = 0x3C, bool reset = true);


### PR DESCRIPTION
Hi Limor, & Adafruit pals.

I recently bought a sample of a 256x64 OLED panel based on the SSD1322 controller from a supplier. I wanted to use the panel in its grayscale mode, so I adapted Limor's SSD1327 driver [on a fresh fork](https://github.com/jordanh/Adafruit_SSD1322).

A difference between the SSD1327 controller and the SSD1322 controller is how the SSD1322 receives commands vs. data. The SSD1327 D/C# pin is always logically false ("command") when commands and arguments are sent. The SSD1322, on the other hand, requires arguments to be sent as ("data") with the D/C# pin high.

## Description of changes
The  `oled_commandList()` method does not control the D/C# pin for the SSD1327 controller, so a new method `oled_commandAndArglist()` has been added. The method asserts D/C# low for each command byte, and high for each argument byte.

It works like this:

```c
  static const uint8_t init_256x64[] {
    2, 0xfd, 0x12,            	        /* unlock */
    1, 0xae,		                /* display off */
    2, 0xb3, 0x91,			/* set display clock divide ratio/oscillator frequency (set clock as 80 frames/sec)  */  
    2, 0xca, 0x3f,			/* multiplex ratio 1/64 Duty (0x0F~0x3F) */  
    2, 0xa2, 0x00,			/* display offset, shift mapping ram counter */  
    2, 0xa1, 0x00,			/* display start line */  
    3, 0xa0, 0x06, 0x11,	        /* Set Re-Map / Dual COM Line Mode */
    2, 0xab, 0x01,			/* Enable Internal VDD Regulator */  
    3, 0xb4, 0xa0, 0x05|0xfd,	        /* Display Enhancement A */  
    2, 0xc1, 0x9f,			/* contrast */  
    2, 0xc7, 0x0f,			/* Set Scale Factor of Segment Output Current Control */  
    1, 0xb9,		                /* linear grayscale */
    2, 0xb1, 0xe2,			/* Phase 1 (Reset) & Phase 2 (Pre-Charge) Period Adjustment */  
    3, 0xd1, 0x82|0x20, 0x20,	        /* Display Enhancement B */  
    2, 0xbb, 0x1f,			/* precharge  voltage */  
    2, 0xb6, 0x08,			/* precharge  period */  
    2, 0xbe, 0x07,			/* vcomh */  
    1, 0xa6,		                /* normal display */
    1, 0xa9		                /* exit partial display */
  };
  
  if (!oled_commandAndArgsList(init_256x64, sizeof(init_256x64))) {
    return false;
  }
```

See also, [full implementation for SSD1322](https://github.com/jordanh/Adafruit_SSD1322).

## Limitations
This introduces two means of specifying list of display commands to  the `Adafruit_GrayOLED` class. I don't love the duplication or how each method implicitly handles the D/C# pin. A better approach might be to modify `oled_commandList()` to use a similarly specified list of command and args as my `oled_commandAndArglist()` method and add a bool argument `argAsData` to define whether or not D/C# is asserted when sending command arguments. For example:

```c
  static const uint8_t init_256x64[] {
    2, 0xfd, 0x12,            	        /* unlock */
    /* ... * /
    3, 0xb4, 0xa0, 0x05|0xfd,	        /* Display Enhancement A */  
    2, 0xc1, 0x9f,			/* contrast */  
     /* ... * / 
    1, 0xa9		                /* exit partial display */
  };
  
  if (!oled_commandList(init_256x64, sizeof(init_256x64), /* argAsData */ true)) {
    return false;
  }
```

I didn't want to introduce this change to your interface as a few downstream drivers depend on it. If you prefer it, I'd be happy to give PRs against the existing Adafruit drivers that rely on `Adafruit_GrayOLED::oled_commandList()`. If you want to go that route, just let me know in the comments here and we can coordinate.

