### PR TITLE
Fix compiler errors thrown by recent Particle cloud compiler updates

### DIFF
--- a/Adafruit_SPITFT.cpp
+++ b/Adafruit_SPITFT.cpp
@@ -560,7 +560,7 @@ void Adafruit_SPITFT::initSPI(uint32_t freq, uint8_t spiMode) {
     if (
 #if !defined(SPI_INTERFACES_COUNT)
         1
-#endif
+#else
 #if SPI_INTERFACES_COUNT > 0
         (hwspi._spi == &SPI)
 #endif
@@ -579,6 +579,7 @@ void Adafruit_SPITFT::initSPI(uint32_t freq, uint8_t spiMode) {
 #if SPI_INTERFACES_COUNT > 5
         || (hwspi._spi == &SPI5)
 #endif
+#endif // end SPI_INTERFACES_COUNT
     ) {
       hwspi._spi->begin();
     }

--- a/Adafruit_SPITFT.h
+++ b/Adafruit_SPITFT.h
@@ -154,6 +154,10 @@ public:
                   int8_t wr, int8_t dc, int8_t cs = -1, int8_t rst = -1,
                   int8_t rd = -1);
 
+  // DESTRUCTOR ----------------------------------------------------------
+
+  ~Adafruit_SPITFT() {};
+
   // CLASS MEMBER FUNCTIONS ----------------------------------------------
 
   // These first two functions MUST be declared by subclasses:

--- a/Adafruit_SPITFT.h
+++ b/Adafruit_SPITFT.h
@@ -156,7 +156,7 @@ public:
 
   // DESTRUCTOR ----------------------------------------------------------
 
-  ~Adafruit_SPITFT() {};
+  ~Adafruit_SPITFT(){};
 
   // CLASS MEMBER FUNCTIONS ----------------------------------------------
 


### PR DESCRIPTION
The Particle cloud compiler has recently gotten grouchier / more exacting about warnings; these two fixes are needed to make this repo compile.

### Adafruit_SPITFT.h

This error is a bit inscrutable:

```
In file included from Adafruit_SPITFT.cpp:36:
Adafruit_SPITFT.h:119:7: error: deleted function 'virtual Adafruit_SPITFT::~Adafruit_SPITFT()' overriding non-deleted function
   119 | class Adafruit_SPITFT : public Adafruit_GFX {
       |       ^~~~~~~~~~~~~~~
 In file included from Adafruit_SPITFT.h:25,
                  from Adafruit_SPITFT.cpp:36:
 Adafruit_GFX.h:15:7: note: overridden function is 'virtual Adafruit_GFX::~Adafruit_GFX()'
    15 | class Adafruit_GFX : public Print {
       |       ^~~~~~~~~~~~
 In file included from Adafruit_SPITFT.cpp:36:
 Adafruit_SPITFT.h:119:7: note: 'virtual Adafruit_SPITFT::~Adafruit_SPITFT()' is implicitly deleted because the default definition would be ill-formed:
   119 | class Adafruit_SPITFT : public Adafruit_GFX {
       |       ^~~~~~~~~~~~~~~
 Adafruit_SPITFT.h:405:7: error: union member 'Adafruit_SPITFT::<unnamed union>::hwspi' with non-trivial 'Adafruit_SPITFT::<unnamed union>::<unnamed struct>::~<constructor>()'
   405 |     } hwspi;          ///< Hardware SPI values
       |       ^~~~~
 Adafruit_SPITFT.cpp: In constructor 'Adafruit_SPITFT::Adafruit_SPITFT(uint16_t, uint16_t, int8_t, int8_t, int8_t)':
 Adafruit_SPITFT.cpp:247:46: error: use of deleted function 'virtual Adafruit_SPITFT::~Adafruit_SPITFT()'
   247 |     : Adafruit_SPITFT(w, h, &SPI, cs, dc, rst) {
       |                                              ^
 ../build/module.mk:274: recipe for target '../build/target/user/platform-12-mAdafruit_SPITFT.o' failed
```

My best explanation for this is that on the Particle platform, `SPISettings` eventually derives from `Printable` which has a vtable; explicitly declaring the destructor `~Adafruit_SPITFT()` makes the compiler happy.

### Adafruit_SPITFT.cpp

A legitimate complaint:

```
Adafruit_SPITFT.cpp:564:5: warning: "SPI_INTERFACES_COUNT" is not defined, evaluates to 0 [-Wundef]
...
```

Addressed by nesting the #ifdefs.