### PR TITLE
Fix 2 recent problems with SPITFT begin and its destructor

### DIFF
--- a/Adafruit_SPITFT.cpp
+++ b/Adafruit_SPITFT.cpp
@@ -99,6 +99,46 @@ static const struct {
 // CONSTRUCTORS ------------------------------------------------------------
 
 /*!
+    @brief Is a SPI interface provided by the variant?
+
+    An "established" SPI interface is one of the ones defined by "variants.h",
+    rather than being user-defined.
+
+    @param   spiClass  Pointer to SPIClass type (e.g. &SPI or &SPI1).
+    @return  True if spiClass is one of the variant-provided SPI interfaces.
+ */
+static bool isVariantDefinedSPIInterface(SPIClass *spiClass) {
+// Older variants assume a count of 1 without providing count explicitly.
+#if defined(SPI_INTERFACES_COUNT)
+#define REAL_SPI_INTERFACES_COUNT SPI_INTERFACES_COUNT
+#else
+#define REAL_SPI_INTERFACES_COUNT 1
+#endif
+
+  return false
+#if REAL_SPI_INTERFACES_COUNT > 0
+         || (spiClass == &SPI) // the 0-th SPI.
+#endif
+#if REAL_SPI_INTERFACES_COUNT > 1
+         || (spiClass == &SPI1)
+#endif
+#if REAL_SPI_INTERFACES_COUNT > 2
+         || (spiClass == &SPI2)
+#endif
+#if REAL_SPI_INTERFACES_COUNT > 3
+         || (spiClass == &SPI3)
+#endif
+#if REAL_SPI_INTERFACES_COUNT > 4
+         || (spiClass == &SPI4)
+#endif
+#if REAL_SPI_INTERFACES_COUNT > 5
+         || (spiClass == &SPI5)
+#endif
+      ;
+#undef REAL_SPI_INTERFACES_COUNT
+}
+
+/*!
     @brief   Adafruit_SPITFT constructor for software (bitbang) SPI.
     @param   w     Display width in pixels at default rotation setting (0).
     @param   h     Display height in pixels at default rotation setting (0).
@@ -557,30 +597,7 @@ void Adafruit_SPITFT::initSPI(uint32_t freq, uint8_t spiMode) {
     // SERCOM so we can't make those calls ourselves here. And the SPI
     // device needs to be set up before calling this because it's
     // immediately followed with initialization commands. Blargh.
-    if (
-#if !defined(SPI_INTERFACES_COUNT)
-        1
-#else
-#if SPI_INTERFACES_COUNT > 0
-        (hwspi._spi == &SPI)
-#endif
-#if SPI_INTERFACES_COUNT > 1
-        || (hwspi._spi == &SPI1)
-#endif
-#if SPI_INTERFACES_COUNT > 2
-        || (hwspi._spi == &SPI2)
-#endif
-#if SPI_INTERFACES_COUNT > 3
-        || (hwspi._spi == &SPI3)
-#endif
-#if SPI_INTERFACES_COUNT > 4
-        || (hwspi._spi == &SPI4)
-#endif
-#if SPI_INTERFACES_COUNT > 5
-        || (hwspi._spi == &SPI5)
-#endif
-#endif // end SPI_INTERFACES_COUNT
-    ) {
+    if (isVariantDefinedSPIInterface(hwspi._spi)) {
       hwspi._spi->begin();
     }
   } else if (connection == TFT_SOFT_SPI) {

--- a/Adafruit_SPITFT.cpp
+++ b/Adafruit_SPITFT.cpp
@@ -543,6 +543,28 @@ Adafruit_SPITFT::Adafruit_SPITFT(uint16_t w, uint16_t h, tftBusWidth busWidth,
 
 // end constructors -------
 
+
+// DESTRUCTOR ----------------------------------------------------------
+
+template <typename T>
+static void explicitlyDestroy(const T* obj) {
+    obj->~T();
+}
+
+Adafruit_SPITFT::~Adafruit_SPITFT() {
+  switch (connection) {
+  case TFT_HARD_SPI:
+    explicitlyDestroy(&hwspi);
+    break;
+  case TFT_SOFT_SPI:
+    explicitlyDestroy(&swspi);
+    break;
+  case TFT_PARALLEL:
+    explicitlyDestroy(&tft8);
+    break;
+  }
+}
+
 // CLASS MEMBER FUNCTIONS --------------------------------------------------
 
 // begin() and setAddrWindow() MUST be declared by any subclass.

--- a/Adafruit_SPITFT.h
+++ b/Adafruit_SPITFT.h
@@ -156,7 +156,7 @@ public:
 
   // DESTRUCTOR ----------------------------------------------------------
 
-  ~Adafruit_SPITFT(){};
+  ~Adafruit_SPITFT();
 
   // CLASS MEMBER FUNCTIONS ----------------------------------------------
 


### PR DESCRIPTION
Fixes two problems identified by examination of PR #333.
These are two separable commits in the PR.

-  Destructor is responsible for destroying the active union member

-   Handle SPI_INTERFACES_COUNT==0
