### PR TITLE
[Docs] Add a reference to the GFX Font customiser in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Recent Arduino IDE releases include the Library Manager for easy installation. O
 
 - 'fontconvert' folder contains a command-line tool for converting TTF fonts to Adafruit_GFX header format.
 
+- You can also use [this GFX Font Customiser tool](https://github.com/tchapi/Adafruit-GFX-Font-Customiser) (_web version [here](https://tchapi.github.io/Adafruit-GFX-Font-Customiser/)_) to customize or correct the output from [fontconvert](https://github.com/adafruit/Adafruit-GFX-Library/tree/master/fontconvert), and create fonts with only a subset of characters to optimize size.
+
 ---
 
 ### Roadmap


### PR DESCRIPTION
> **Scope**  This is only an added paragraph in the `README.md` file

Hello Adafruit,

As a long-time user of the Adafruit libraries, I have often been struggling with fonts on embedded systems that had little space / limited processing power, while trying to create legible and somehow _beautiful_ interfaces.

Since I'm not a typographer, I've always resorted to using TT fonts, convert them, and use that in my sketches, but unfortunately the results were not always perfect (missing pixels, wrong alignment, missing accented characters, etc).
I thus created and maintain a tool (_along with other fantastic contributors_) to customize the output of **fontconvert**.

This tool allows to: 
  - edit fonts with a graphical interface, adding and correcting pixels here and there quite easily
  - modify advance, offset, baseline, etc for glyphs
  - disable glyphs entirely in order to save space, without resorting to the hack of using a character for another
  - create a font from scratch by including only the necessary characters (_say, you only want numbers, a minus sign, `C`and `F` to display temperatures_) and optimizing the font file size

I believe this could be useful to the community and that it may help developers landing on the GFX Github page, hence this little paragraph that I humbly propose to add.

Thanks !
