### PR TITLE
update drawXBitmap to draw background pixels, matching drawBitmap functionality

### DIFF
--- a/Adafruit_GFX.cpp
+++ b/Adafruit_GFX.cpp
@@ -846,10 +846,11 @@ void Adafruit_GFX::drawBitmap(int16_t x, int16_t y, uint8_t *bitmap, int16_t w,
     @param    w   Width of bitmap in pixels
     @param    h   Height of bitmap in pixels
     @param    color 16-bit 5-6-5 Color to draw pixels with
+    @param    bg 16-bit 5-6-5 Color to draw background with
 */
 /**************************************************************************/
 void Adafruit_GFX::drawXBitmap(int16_t x, int16_t y, const uint8_t bitmap[],
-                               int16_t w, int16_t h, uint16_t color) {
+                               int16_t w, int16_t h, uint16_t color, uint16_t bg) {
 
   int16_t byteWidth = (w + 7) / 8; // Bitmap scanline pad = whole byte
   uint8_t byte = 0;
@@ -863,8 +864,7 @@ void Adafruit_GFX::drawXBitmap(int16_t x, int16_t y, const uint8_t bitmap[],
         byte = pgm_read_byte(&bitmap[j * byteWidth + i / 8]);
       // Nearly identical to drawBitmap(), only the bit order
       // is reversed here (left-to-right = LSB to MSB):
-      if (byte & 0x01)
-        writePixel(x + i, y, color);
+        writePixel(x + i, y, (byte & 0x01) ? color : bg);
     }
   }
   endWrite();

--- a/Adafruit_GFX.cpp
+++ b/Adafruit_GFX.cpp
@@ -850,7 +850,7 @@ void Adafruit_GFX::drawBitmap(int16_t x, int16_t y, uint8_t *bitmap, int16_t w,
 */
 /**************************************************************************/
 void Adafruit_GFX::drawXBitmap(int16_t x, int16_t y, const uint8_t bitmap[],
-                               int16_t w, int16_t h, uint16_t color, 
+                               int16_t w, int16_t h, uint16_t color,
                                uint16_t bg) {
 
   int16_t byteWidth = (w + 7) / 8; // Bitmap scanline pad = whole byte

--- a/Adafruit_GFX.cpp
+++ b/Adafruit_GFX.cpp
@@ -850,7 +850,8 @@ void Adafruit_GFX::drawBitmap(int16_t x, int16_t y, uint8_t *bitmap, int16_t w,
 */
 /**************************************************************************/
 void Adafruit_GFX::drawXBitmap(int16_t x, int16_t y, const uint8_t bitmap[],
-                               int16_t w, int16_t h, uint16_t color, uint16_t bg) {
+                               int16_t w, int16_t h, uint16_t color, 
+                               uint16_t bg) {
 
   int16_t byteWidth = (w + 7) / 8; // Bitmap scanline pad = whole byte
   uint8_t byte = 0;

--- a/Adafruit_GFX.cpp
+++ b/Adafruit_GFX.cpp
@@ -864,7 +864,7 @@ void Adafruit_GFX::drawXBitmap(int16_t x, int16_t y, const uint8_t bitmap[],
         byte = pgm_read_byte(&bitmap[j * byteWidth + i / 8]);
       // Nearly identical to drawBitmap(), only the bit order
       // is reversed here (left-to-right = LSB to MSB):
-        writePixel(x + i, y, (byte & 0x01) ? color : bg);
+      writePixel(x + i, y, (byte & 0x01) ? color : bg);
     }
   }
   endWrite();

--- a/Adafruit_GFX.h
+++ b/Adafruit_GFX.h
@@ -87,7 +87,7 @@ public:
   void drawBitmap(int16_t x, int16_t y, uint8_t *bitmap, int16_t w, int16_t h,
                   uint16_t color, uint16_t bg);
   void drawXBitmap(int16_t x, int16_t y, const uint8_t bitmap[], int16_t w,
-                   int16_t h, uint16_t color);
+                   int16_t h, uint16_t color, uint16_t bg);
   void drawGrayscaleBitmap(int16_t x, int16_t y, const uint8_t bitmap[],
                            int16_t w, int16_t h);
   void drawGrayscaleBitmap(int16_t x, int16_t y, uint8_t *bitmap, int16_t w,


### PR DESCRIPTION
I modified Adafruit_GFX.cpp and Adafruit_GFX.h to match the functionality of drawBitmap so that it can draw background pixels. In my application I was creating an animation using drawXBitmap, because it did not draw background pixels, each frame would end up stacking on top of each other. 

The workarounds I tried were to do a fillScreen with the background color and then redraw all of the other elements, but this created flickering and poor performance. I also tried redrawing the x bitmap twice, once with the foreground color delaying, then drawing with the background color to erase it, this also had poor performance and flickering. 

So I modified the library by copying some of the drawBitmap code and modifying it slightly so that it continues to work for x bitmaps and draws a background color. This was tested with a 64x64 px 45 frame animation on an Feather M4 Express with a 2.4" TFT FeatherWing (product id 3315), and it worked well both for static x bitmap and the animation.

This will break functionality for existing code using the library since it now requires a background color parameter. Maintaining functionality would require adding more complexity to the code (an additional bool flag parameter, and an if statement to either draw background pixels or not). Please let me know if this would be a better way to do it and I'll implement and test that functionality and update the PR accordingly.

Thank you!