### PR TITLE
Add function overload for drawXBitmap to draw a background color

### DIFF
--- a/Adafruit_GFX.cpp
+++ b/Adafruit_GFX.cpp
@@ -872,6 +872,44 @@ void Adafruit_GFX::drawXBitmap(int16_t x, int16_t y, const uint8_t bitmap[],
 
 /**************************************************************************/
 /*!
+   @brief      Draw PROGMEM-resident XBitMap Files (*.xbm), exported from GIMP.
+   Usage: Export from GIMP to *.xbm, rename *.xbm to *.c and open in editor.
+   C Array can be directly used with this function.
+   There is no RAM-resident version of this function; if generating bitmaps
+   in RAM, use the format defined by drawBitmap() and call that instead.
+    @param    x   Top left corner x coordinate
+    @param    y   Top left corner y coordinate
+    @param    bitmap  byte array with monochrome bitmap
+    @param    w   Width of bitmap in pixels
+    @param    h   Height of bitmap in pixels
+    @param    color 16-bit 5-6-5 Color to draw pixels with
+    @param    bg 16-bit 5-6-5 Color to draw background with
+*/
+/**************************************************************************/
+void Adafruit_GFX::drawXBitmap(int16_t x, int16_t y, const uint8_t bitmap[],
+                               int16_t w, int16_t h, uint16_t color,
+                               uint16_t bg) {
+
+  int16_t byteWidth = (w + 7) / 8; // Bitmap scanline pad = whole byte
+  uint8_t byte = 0;
+
+  startWrite();
+  for (int16_t j = 0; j < h; j++, y++) {
+    for (int16_t i = 0; i < w; i++) {
+      if (i & 7)
+        byte >>= 1;
+      else
+        byte = pgm_read_byte(&bitmap[j * byteWidth + i / 8]);
+      // Nearly identical to drawBitmap(), only the bit order
+      // is reversed here (left-to-right = LSB to MSB):
+      writePixel(x + i, y, (byte & 0x01) ? color : bg);
+    }
+  }
+  endWrite();
+}
+
+/**************************************************************************/
+/*!
    @brief   Draw a PROGMEM-resident 8-bit image (grayscale) at the specified
    (x,y) pos. Specifically for 8-bit display devices such as IS31FL3731; no
    color reduction/expansion is performed.

--- a/Adafruit_GFX.h
+++ b/Adafruit_GFX.h
@@ -88,6 +88,8 @@ public:
                   uint16_t color, uint16_t bg);
   void drawXBitmap(int16_t x, int16_t y, const uint8_t bitmap[], int16_t w,
                    int16_t h, uint16_t color);
+  void drawXBitmap(int16_t x, int16_t y, const uint8_t bitmap[], int16_t w,
+                   int16_t h, uint16_t color, uint16_t bg);
   void drawGrayscaleBitmap(int16_t x, int16_t y, const uint8_t bitmap[],
                            int16_t w, int16_t h);
   void drawGrayscaleBitmap(int16_t x, int16_t y, uint8_t *bitmap, int16_t w,


### PR DESCRIPTION
I modified Adafruit_GFX.cpp and Adafruit_GFX.h to match the functionality of drawBitmap so that it can draw background pixels. This was implemented as a function overload to avoid breaking compatibility with existing code.

In my application I was creating an animation using drawXBitmap, because it did not draw background pixels, each frame would end up stacking on top of each other.

The workarounds I tried were to do a fillScreen with the background color and then redraw all of the other elements, but this created flickering and poor performance. I also tried redrawing the x bitmap twice, once with the foreground color delaying, then drawing with the background color to erase it, this also had poor performance and flickering.

So I modified the library by copying some of the drawBitmap code and modifying it slightly so that it continues to work for x bitmaps and draws a background color. This was tested with a 64x64 px 45 frame animation on an Feather M4 Express with a 2.4" TFT FeatherWing (product id 3315), and it worked well both for static x bitmap images and the animation.

