### PR TITLE
Add ability to set a user defined DMA transfer callback

### DIFF
--- a/Adafruit_SPITFT.cpp
+++ b/Adafruit_SPITFT.cpp
@@ -61,7 +61,13 @@
 
 // DMA transfer-in-progress indicator and callback
 static volatile bool dma_busy = false;
-static void dma_callback(Adafruit_ZeroDMA *dma) { dma_busy = false; }
+static void(*s_dma_complete_callback)() = nullptr; // User defined callback
+static void dma_callback(Adafruit_ZeroDMA *dma) {
+  dma_busy = false;
+  if (s_dma_complete_callback) {
+    s_dma_complete_callback();
+  }
+}
 
 #if defined(__SAMD51__)
 // Timer/counter info by index #
@@ -1129,6 +1135,19 @@ void Adafruit_SPITFT::dmaWait(void) {
     pinPeripheral(tft8._wr, PIO_OUTPUT); // Switch WR back to GPIO
   }
 #endif // end __SAMD51__ || ARDUINO_SAMD_ZERO
+#endif
+}
+
+/*!
+    @brief  Set callback to be executed when the last DMA transfer in a
+            prior non-blocking writePixels() call completes. If DMA is
+            not enabled or writePixels is used in a blocking manner (as
+            is the default case), then this callback will not be used.
+*/
+void Adafruit_SPITFT::dmaSetCallback(void(*callback)())
+{
+#if defined(USE_SPI_DMA) && (defined(__SAMD51__) || defined(ARDUINO_SAMD_ZERO))
+  s_dma_complete_callback = callback;
 #endif
 }
 

--- a/Adafruit_SPITFT.h
+++ b/Adafruit_SPITFT.h
@@ -231,6 +231,7 @@ public:
   // Another new function, companion to the new non-blocking
   // writePixels() variant.
   void dmaWait(void);
+  static void dmaSetCallback(void(*callback)());
 
   // These functions are similar to the 'write' functions above, but with
   // a chip-select and/or SPI transaction built-in. They're typically used

--- a/Adafruit_SPITFT.h
+++ b/Adafruit_SPITFT.h
@@ -231,6 +231,8 @@ public:
   // Another new function, companion to the new non-blocking
   // writePixels() variant.
   void dmaWait(void);
+
+  // Set user defined DMA transfer completion callback
   static void dmaSetCallback(void(*callback)());
 
   // These functions are similar to the 'write' functions above, but with


### PR DESCRIPTION
- This allows the user to avoid unnecessary spin locks while waiting for a DMA transfer to complete.
- This has the same limitations as the `dmaWait()` function in terms of supported devices.

- This has been tested on PyGamer M4 to signal to the application that a framebuffer copy has completed and the framebuffer can be modified before initiating the next DMA transfer. In essence this allows us to mimic a vblank interrupt (though a lack of broken out sync pin from the display module prevents us avoiding tearing altogether).

- If you require a direct test example, do let me know and I’ll throw something together.