### PR TITLE
Optimisations for RP2040

### DIFF
--- a/Adafruit_SPITFT.cpp
+++ b/Adafruit_SPITFT.cpp
@@ -993,8 +993,10 @@ void Adafruit_SPITFT::writePixels(uint16_t *colors, uint32_t len, bool block,
     return;
   }
 #elif defined(ARDUINO_ARCH_RP2040)
-  spi_write16_blocking(spi0, (const uint16_t*)colors, len);
-  return;
+  if (connection == TFT_HARD_SPI) {
+    spi_write16_blocking(spi0, (const uint16_t*)colors, len);
+    return;
+  }
 #elif defined(ARDUINO_NRF52_ADAFRUIT) &&                                       \
     defined(NRF52840_XXAA) // Adafruit nRF52 use SPIM3 DMA at 32Mhz
   // TFT and SPI DMA endian is different we need to swap bytes
@@ -2375,7 +2377,7 @@ inline bool Adafruit_SPITFT::SPI_MISO_READ(void) {
             transaction and data/command selection must have been
             previously set -- this ONLY issues the word. Despite the name,
             this function is used even if display connection is parallel;
-            name was maintaned for backward compatibility. Naming is also
+            name was maintained for backward compatibility. Naming is also
             not consistent with the 8-bit version, spiWrite(). Sorry about
             that. Again, staying compatible with outside code.
     @param  w  16-bit value to write.

--- a/Adafruit_SPITFT.cpp
+++ b/Adafruit_SPITFT.cpp
@@ -992,6 +992,9 @@ void Adafruit_SPITFT::writePixels(uint16_t *colors, uint32_t len, bool block,
     hwspi._spi->writePixels(colors, len * 2);
     return;
   }
+#elif defined(ARDUINO_ARCH_RP2040)
+  spi_write16_blocking(spi0, (const uint16_t*)colors, len);
+  return;
 #elif defined(ARDUINO_NRF52_ADAFRUIT) &&                                       \
     defined(NRF52840_XXAA) // Adafruit nRF52 use SPIM3 DMA at 32Mhz
   // TFT and SPI DMA endian is different we need to swap bytes
@@ -1302,7 +1305,25 @@ void Adafruit_SPITFT::writeColor(uint16_t color, uint32_t len) {
         hwspi._spi->write(lo);
       }
     } while (len);
-#else // !ESP8266
+#elif defined(ARDUINO_ARCH_RP2040)
+    bool loaded = false;
+    uint16_t colorBuf[64];
+    const uint16_t* colorPtr = colorBuf;
+    if (len>63) {
+      loaded = true;
+      for (uint32_t i = 0; i < 64; i++) colorBuf[i] = color;
+      while(len>63) {
+        spi_write16_blocking(spi0, (const uint16_t*)colorPtr, 64);
+        len -=64;
+      }
+    }
+
+    if (len) {
+      if (!loaded) for (uint32_t i = 0; i < len; i++) colorBuf[i] = color;
+      spi_write16_blocking(spi0, (const uint16_t*)colorPtr, len);
+    }
+    return;
+#else // !ESP8266 or RP2040
     while (len--) {
 #if defined(__AVR__)
       AVR_WRITESPI(hi);
@@ -2055,6 +2076,11 @@ void Adafruit_SPITFT::spiWrite(uint8_t b) {
     AVR_WRITESPI(b);
 #elif defined(ESP8266) || defined(ESP32)
     hwspi._spi->write(b);
+#elif defined(ARDUINO_ARCH_RP2040)
+    spi_set_format(spi0,  8, (spi_cpol_t)0, (spi_cpha_t)0, SPI_MSB_FIRST);
+    spi_write_blocking(spi0, (const uint8_t*)&(b), 1);
+    spi_set_format(spi0, 16, (spi_cpol_t)0, (spi_cpha_t)0, SPI_MSB_FIRST);
+    return;
 #else
     hwspi._spi->transfer(b);
 #endif
@@ -2361,6 +2387,8 @@ void Adafruit_SPITFT::SPI_WRITE16(uint16_t w) {
     AVR_WRITESPI(w);
 #elif defined(ESP8266) || defined(ESP32)
     hwspi._spi->write16(w);
+#elif defined(ARDUINO_ARCH_RP2040)
+    spi_write16_blocking(spi0, (const uint16_t*)&(w), 1);
 #else
     hwspi._spi->transfer(w >> 8);
     hwspi._spi->transfer(w);
@@ -2398,7 +2426,7 @@ void Adafruit_SPITFT::SPI_WRITE16(uint16_t w) {
             transaction and data/command selection must have been
             previously set -- this ONLY issues the longword. Despite the
             name, this function is used even if display connection is
-            parallel; name was maintaned for backward compatibility. Naming
+            parallel; name was maintained for backward compatibility. Naming
             is also not consistent with the 8-bit version, spiWrite().
             Sorry about that. Again, staying compatible with outside code.
     @param  l  32-bit value to write.
@@ -2412,6 +2440,8 @@ void Adafruit_SPITFT::SPI_WRITE32(uint32_t l) {
     AVR_WRITESPI(l);
 #elif defined(ESP8266) || defined(ESP32)
     hwspi._spi->write32(l);
+#elif defined(ARDUINO_ARCH_RP2040)
+    spi_write16_blocking(spi0, (const uint16_t*)&(l), 2);
 #else
     hwspi._spi->transfer(l >> 24);
     hwspi._spi->transfer(l >> 16);

--- a/Adafruit_SPITFT.h
+++ b/Adafruit_SPITFT.h
@@ -295,6 +295,8 @@ public:
 #else  // !HAS_PORT_SET_CLR
     *csPort |= csPinMaskSet;
 #endif // end !HAS_PORT_SET_CLR
+#elif defined (ARDUINO_ARCH_RP2040)
+    sio_hw->gpio_set = (1ul << _cs);
 #else  // !USE_FAST_PINIO
     digitalWrite(_cs, HIGH);
 #endif // end !USE_FAST_PINIO
@@ -317,6 +319,8 @@ public:
 #else  // !HAS_PORT_SET_CLR
     *csPort &= csPinMaskClr;
 #endif // end !HAS_PORT_SET_CLR
+#elif defined (ARDUINO_ARCH_RP2040)
+    sio_hw->gpio_clr = (1ul << _cs);
 #else  // !USE_FAST_PINIO
     digitalWrite(_cs, LOW);
 #endif // end !USE_FAST_PINIO
@@ -336,6 +340,8 @@ public:
 #else  // !HAS_PORT_SET_CLR
     *dcPort |= dcPinMaskSet;
 #endif // end !HAS_PORT_SET_CLR
+#elif defined (ARDUINO_ARCH_RP2040)
+    sio_hw->gpio_set = (1ul << _dc);
 #else  // !USE_FAST_PINIO
     digitalWrite(_dc, HIGH);
 #endif // end !USE_FAST_PINIO
@@ -355,6 +361,8 @@ public:
 #else  // !HAS_PORT_SET_CLR
     *dcPort &= dcPinMaskClr;
 #endif // end !HAS_PORT_SET_CLR
+#elif defined (ARDUINO_ARCH_RP2040)
+    sio_hw->gpio_clr = (1ul << _dc);
 #else  // !USE_FAST_PINIO
     digitalWrite(_dc, LOW);
 #endif // end !USE_FAST_PINIO

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+Raspberry PI Pico (RP2040) optimised to work with Earle Philhower's Arduino board package.
+
+
 # Adafruit GFX Library ![Build Status](https://github.com/adafruit/Adafruit-GFX-Library/workflows/Arduino%20Library%20CI/badge.svg)
 
 This is the core graphics library for all our displays, providing a common set of graphics primitives (points, lines, circles, etc.). It needs to be paired with a hardware-specific library for each display device we carry (to handle the lower-level functions).


### PR DESCRIPTION
These changes plus a companion pull request for Adafruit_GFX provide performance benefits for the RP2040 based boards when used in hardware SPI mode.

I suspect this pull needs to be refactored since SPI code has been introduced herein which breaks the partioning with Adafruit_GFX library. Also, although this works with Earle Philhower's Arduino core and calls low level SPI code, it may not be compatible with the "official" Arduino RP2040 core.

Performance improvements when used with Adafruit_ILI9431:
![image](https://user-images.githubusercontent.com/15824805/113461418-6c2bd200-9414-11eb-8b78-9b9c0a866089.png)

