### PR TITLE
Added function getLabel() to expose the button label.

### DIFF
--- a/Adafruit_GFX.h
+++ b/Adafruit_GFX.h
@@ -291,6 +291,14 @@ public:
   /**********************************************************************/
   bool isPressed(void) { return currstate; };
 
+  /**********************************************************************/
+  /*!
+    @brief    Get the label text
+    @returns  the const char pointer of the buttoś label
+  */
+  /**********************************************************************/
+  char *getLabel(void) const { return _label; };
+
 private:
   Adafruit_GFX *_gfx;
   int16_t _x1, _y1; // Coordinates of top-left corner


### PR DESCRIPTION
This change affects only the file "Adafruit_GFX.h". Changes the Adafruit_GFX_Button class to expose the button's label thru the constant function" getLabel()".
I've run the code succesfully thru the mega board. 
