### PR TITLE
Adafruit_GFX_Button & Adafruit_GFX changes: pressedcolor, radius, custom fonts.

### DIFF
--- a/Adafruit_GFX.cpp
+++ b/Adafruit_GFX.cpp
@@ -1838,7 +1838,8 @@ void Adafruit_GFX_Button::drawButton(bool inverted) {
 	_gfx->setCursor(_x1 + (_w / 2) - (strlen(_label) * 3 * _textsize_x),
                   _y1 + (_h / 2) - (4 * _textsize_y));
   }
-  _gfx->setTextColor(text);
+ 
+ _gfx->setTextColor(text);
   _gfx->setTextSize(_textsize_x, _textsize_y);
   _gfx->print(_label);
 }

--- a/Adafruit_GFX.cpp
+++ b/Adafruit_GFX.cpp
@@ -1546,6 +1546,20 @@ void Adafruit_GFX::invertDisplay(bool i) {
 
 /**************************************************************************/
 /*!
+    @brief      Invert the display (ideally using built-in hardware command)
+    @param   i  True if you want to invert, false to make 'normal'
+*/
+/**************************************************************************/
+GFXfont* Adafruit_GFX::getFont()
+{
+  return gfxFont;
+  
+}
+/***************************************************************************/
+
+
+/**************************************************************************/
+/*!
    @brief    Create a simple drawn button UI element
 */
 /**************************************************************************/
@@ -1572,7 +1586,7 @@ void Adafruit_GFX_Button::initButton(Adafruit_GFX *gfx, int16_t x, int16_t y,
                                      uint16_t fill, uint16_t textcolor,
                                      char *label, uint8_t textsize) {
   // Tweak arguments and pass to the newer initButtonUL() function...
-  initButtonUL(gfx, x - (w / 2), y - (h / 2), w, h, outline, fill, textcolor,
+  initButtonUL(gfx, x - (w / 2), y - (h / 2), w, h, outline, fill, textcolor, textcolor,
                label, textsize);
 }
 
@@ -1599,9 +1613,64 @@ void Adafruit_GFX_Button::initButton(Adafruit_GFX *gfx, int16_t x, int16_t y,
                                      char *label, uint8_t textsize_x,
                                      uint8_t textsize_y) {
   // Tweak arguments and pass to the newer initButtonUL() function...
-  initButtonUL(gfx, x - (w / 2), y - (h / 2), w, h, outline, fill, textcolor,
+  initButtonUL(gfx, x - (w / 2), y - (h / 2), w, h, outline, fill, textcolor, textcolor,
                label, textsize_x, textsize_y);
 }
+
+/**************************************************************************/
+/*!
+   @brief    Initialize button with our desired color/size/settings
+   @param    gfx     Pointer to our display so we can draw to it!
+   @param    x       The X coordinate of the center of the button
+   @param    y       The Y coordinate of the center of the button
+   @param    w       Width of the buttton
+   @param    h       Height of the buttton
+   @param    outline  Color of the outline (16-bit 5-6-5 standard)
+   @param    fill  Color of the button fill (16-bit 5-6-5 standard)
+   @param    textcolor  Color of the button label (16-bit 5-6-5 standard)
+   @param    pressedcolor the background colour to use when the button is pressed
+   @param    label  Ascii string of the text inside the button
+   @param    textsize The font magnification of the label text
+*/
+/**************************************************************************/
+// Classic initButton() function: pass center & size
+void Adafruit_GFX_Button::initButton(Adafruit_GFX *gfx, int16_t x, int16_t y,
+                                     uint16_t w, uint16_t h, uint16_t outline,
+                                     uint16_t fill, uint16_t textcolor, uint16_t pressedcolor,
+                                     char *label, uint8_t textsize) {
+  // Tweak arguments and pass to the newer initButtonUL() function...
+  initButtonUL(gfx, x - (w / 2), y - (h / 2), w, h, outline, fill, textcolor, pressedcolor,
+               label, textsize);
+}
+
+/**************************************************************************/
+/*!
+   @brief    Initialize button with our desired color/size/settings
+   @param    gfx     Pointer to our display so we can draw to it!
+   @param    x       The X coordinate of the center of the button
+   @param    y       The Y coordinate of the center of the button
+   @param    w       Width of the buttton
+   @param    h       Height of the buttton
+   @param    outline  Color of the outline (16-bit 5-6-5 standard)
+   @param    fill  Color of the button fill (16-bit 5-6-5 standard)
+   @param    textcolor  Color of the button label (16-bit 5-6-5 standard)
+   @param    pressedcolor the background colour to use when the button is pressed
+   @param    label  Ascii string of the text inside the button
+   @param    textsize_x The font magnification in X-axis of the label text
+   @param    textsize_y The font magnification in Y-axis of the label text
+*/
+/**************************************************************************/
+// Classic initButton() function: pass center & size
+void Adafruit_GFX_Button::initButton(Adafruit_GFX *gfx, int16_t x, int16_t y,
+                                     uint16_t w, uint16_t h, uint16_t outline,
+                                     uint16_t fill, uint16_t textcolor, uint16_t pressedcolor,
+                                     char *label, uint8_t textsize_x,
+                                     uint8_t textsize_y) {
+  // Tweak arguments and pass to the newer initButtonUL() function...
+  initButtonUL(gfx, x - (w / 2), y - (h / 2), w, h, outline, fill, textcolor, pressedcolor,
+               label, textsize_x, textsize_y);
+}
+
 
 /**************************************************************************/
 /*!
@@ -1624,9 +1693,36 @@ void Adafruit_GFX_Button::initButtonUL(Adafruit_GFX *gfx, int16_t x1,
                                        uint16_t outline, uint16_t fill,
                                        uint16_t textcolor, char *label,
                                        uint8_t textsize) {
-  initButtonUL(gfx, x1, y1, w, h, outline, fill, textcolor, label, textsize,
+  initButtonUL(gfx, x1, y1, w, h, outline, fill, textcolor, textcolor, label, textsize,
                textsize);
 }
+
+/**************************************************************************/
+/*!
+   @brief    Initialize button with our desired color/size/settings, with
+   upper-left coordinates
+   @param    gfx     Pointer to our display so we can draw to it!
+   @param    x1       The X coordinate of the Upper-Left corner of the button
+   @param    y1       The Y coordinate of the Upper-Left corner of the button
+   @param    w       Width of the buttton
+   @param    h       Height of the buttton
+   @param    outline  Color of the outline (16-bit 5-6-5 standard)
+   @param    fill  Color of the button fill (16-bit 5-6-5 standard)
+   @param    textcolor  Color of the button label (16-bit 5-6-5 standard)
+   @param    pressedcolor the background colour to use when the button is pressed
+   @param    label  Ascii string of the text inside the button
+   @param    textsize The font magnification of the label text
+*/
+/**************************************************************************/
+void Adafruit_GFX_Button::initButtonUL(Adafruit_GFX *gfx, int16_t x1,
+                                       int16_t y1, uint16_t w, uint16_t h,
+                                       uint16_t outline, uint16_t fill,
+                                       uint16_t textcolor, uint16_t pressedcolor, char *label,
+                                       uint8_t textsize) {
+  initButtonUL(gfx, x1, y1, w, h, outline, fill, textcolor, pressedcolor, label, textsize,
+               textsize);
+}
+
 
 /**************************************************************************/
 /*!
@@ -1650,6 +1746,33 @@ void Adafruit_GFX_Button::initButtonUL(Adafruit_GFX *gfx, int16_t x1,
                                        uint16_t outline, uint16_t fill,
                                        uint16_t textcolor, char *label,
                                        uint8_t textsize_x, uint8_t textsize_y) {
+  initButtonUL(gfx, x1, y1, w, h, outline, fill, textcolor, textcolor, label, textsize_x,
+               textsize_y);
+}
+
+/**************************************************************************/
+/*!
+   @brief    Initialize button with our desired color/size/settings, with
+   upper-left coordinates
+   @param    gfx     Pointer to our display so we can draw to it!
+   @param    x1       The X coordinate of the Upper-Left corner of the button
+   @param    y1       The Y coordinate of the Upper-Left corner of the button
+   @param    w       Width of the buttton
+   @param    h       Height of the buttton
+   @param    outline  Color of the outline (16-bit 5-6-5 standard)
+   @param    fill  Color of the button fill (16-bit 5-6-5 standard)
+   @param    textcolor  Color of the button label (16-bit 5-6-5 standard)
+   @param    pressedcolor the background colour to use when the button is pressed
+   @param    label  Ascii string of the text inside the button
+   @param    textsize_x The font magnification in X-axis of the label text
+   @param    textsize_y The font magnification in Y-axis of the label text
+*/
+/**************************************************************************/
+void Adafruit_GFX_Button::initButtonUL(Adafruit_GFX *gfx, int16_t x1,
+                                       int16_t y1, uint16_t w, uint16_t h,
+                                       uint16_t outline, uint16_t fill,
+                                       uint16_t textcolor, uint16_t pressedcolor, char *label,
+                                       uint8_t textsize_x, uint8_t textsize_y) {
   _x1 = x1;
   _y1 = y1;
   _w = w;
@@ -1657,11 +1780,14 @@ void Adafruit_GFX_Button::initButtonUL(Adafruit_GFX *gfx, int16_t x1,
   _outlinecolor = outline;
   _fillcolor = fill;
   _textcolor = textcolor;
+  _pressedcolor = pressedcolor;
   _textsize_x = textsize_x;
   _textsize_y = textsize_y;
   _gfx = gfx;
-  strncpy(_label, label, 9);
+  strncpy(_label, label, _maxlabellength - 1);
 }
+
+
 
 /**************************************************************************/
 /*!
@@ -1678,20 +1804,48 @@ void Adafruit_GFX_Button::drawButton(bool inverted) {
     outline = _outlinecolor;
     text = _textcolor;
   } else {
-    fill = _textcolor;
+    fill = _pressedcolor;
     outline = _outlinecolor;
     text = _fillcolor;
   }
 
-  uint8_t r = min(_w, _h) / 4; // Corner radius
-  _gfx->fillRoundRect(_x1, _y1, _w, _h, r, fill);
-  _gfx->drawRoundRect(_x1, _y1, _w, _h, r, outline);
-
-  _gfx->setCursor(_x1 + (_w / 2) - (strlen(_label) * 3 * _textsize_x),
+  uint8_t r = 0;
+  if (radius > 0)
+  {
+	 r  = radius;
+	_gfx->fillRoundRect(_x1, _y1, _w, _h, r, fill);
+	_gfx->drawRoundRect(_x1, _y1, _w, _h, r, outline);
+  }
+  else
+  {
+	_gfx->fillRect(_x1, _y1, _w, _h, fill);
+	_gfx->drawRect(_x1, _y1, _w, _h, outline);
+  }
+  
+  if (_gfx->getFont())
+  {
+	// using a proportional font
+    int16_t  x1, y1; 
+	uint16_t w, h;
+	_gfx->getTextBounds(_label, 20, 20, &x1, &y1, &w, &h);
+	int textPosX = _x1 + (_w/2)- ((w/2) * _textsize_x);
+    int textPosY = _y1 + (_h * 0.6);
+	_gfx->setCursor(textPosX, textPosY);
+  }
+  else
+  {
+	// using the system mono-spaced font
+	_gfx->setCursor(_x1 + (_w / 2) - (strlen(_label) * 3 * _textsize_x),
                   _y1 + (_h / 2) - (4 * _textsize_y));
+  }
   _gfx->setTextColor(text);
   _gfx->setTextSize(_textsize_x, _textsize_y);
   _gfx->print(_label);
+}
+
+char* Adafruit_GFX_Button::getLabel()
+{
+	return _label;
 }
 
 /**************************************************************************/

--- a/Adafruit_GFX.cpp
+++ b/Adafruit_GFX.cpp
@@ -1842,6 +1842,7 @@ void Adafruit_GFX_Button::drawButton(bool inverted) {
  _gfx->setTextColor(text);
   _gfx->setTextSize(_textsize_x, _textsize_y);
   _gfx->print(_label);
+  
 }
 
 char* Adafruit_GFX_Button::getLabel()

--- a/Adafruit_GFX.h
+++ b/Adafruit_GFX.h
@@ -322,7 +322,7 @@ public:
   /**********************************************************************/
   char* getLabel();
   
-  int radius = 4;
+  int radius =  4;
   
 private:
   Adafruit_GFX *_gfx;

--- a/Adafruit_GFX.h
+++ b/Adafruit_GFX.h
@@ -332,6 +332,7 @@ private:
   uint8_t _textsize_y;
   uint16_t _outlinecolor, _fillcolor, _textcolor, _pressedcolor;
   
+  
   static const int _maxlabellength = 40;
   char _label[_maxlabellength];
 

--- a/Adafruit_GFX.h
+++ b/Adafruit_GFX.h
@@ -117,6 +117,7 @@ public:
   void setTextSize(uint8_t s);
   void setTextSize(uint8_t sx, uint8_t sy);
   void setFont(const GFXfont *f = NULL);
+  GFXfont* getFont();
 
   /**********************************************************************/
   /*!
@@ -254,9 +255,19 @@ public:
   void initButton(Adafruit_GFX *gfx, int16_t x, int16_t y, uint16_t w,
                   uint16_t h, uint16_t outline, uint16_t fill,
                   uint16_t textcolor, char *label, uint8_t textsize);
+				  
   void initButton(Adafruit_GFX *gfx, int16_t x, int16_t y, uint16_t w,
                   uint16_t h, uint16_t outline, uint16_t fill,
                   uint16_t textcolor, char *label, uint8_t textsize_x,
+                  uint8_t textsize_y);
+				  
+  void initButton(Adafruit_GFX *gfx, int16_t x, int16_t y, uint16_t w,
+                  uint16_t h, uint16_t outline, uint16_t fill,
+                  uint16_t textcolor, uint16_t pressedcolor, char *label, uint8_t textsize);
+				  
+  void initButton(Adafruit_GFX *gfx, int16_t x, int16_t y, uint16_t w,
+                  uint16_t h, uint16_t outline, uint16_t fill,
+                  uint16_t textcolor, uint16_t pressedcolor, char *label, uint8_t textsize_x,
                   uint8_t textsize_y);
   // New/alt initButton() uses upper-left corner & size
   void initButtonUL(Adafruit_GFX *gfx, int16_t x1, int16_t y1, uint16_t w,
@@ -266,6 +277,18 @@ public:
                     uint16_t h, uint16_t outline, uint16_t fill,
                     uint16_t textcolor, char *label, uint8_t textsize_x,
                     uint8_t textsize_y);
+
+
+
+  // New/alt initButton() uses upper-left corner & size
+  void initButtonUL(Adafruit_GFX *gfx, int16_t x1, int16_t y1, uint16_t w,
+                    uint16_t h, uint16_t outline, uint16_t fill,
+                    uint16_t textcolor, uint16_t pressedcolor, char *label, uint8_t textsize);
+  void initButtonUL(Adafruit_GFX *gfx, int16_t x1, int16_t y1, uint16_t w,
+                    uint16_t h, uint16_t outline, uint16_t fill,
+                    uint16_t textcolor, uint16_t pressedcolor, char *label, uint8_t textsize_x,
+                    uint8_t textsize_y);
+					
   void drawButton(bool inverted = false);
   bool contains(int16_t x, int16_t y);
 
@@ -290,15 +313,27 @@ public:
   */
   /**********************************************************************/
   bool isPressed(void) { return currstate; };
-
+  
+  /**********************************************************************/
+  /*!
+    @brief    Get the label text for the button
+    @returns  text shown on the button
+  */
+  /**********************************************************************/
+  char* getLabel();
+  
+  int radius = 4;
+  
 private:
   Adafruit_GFX *_gfx;
   int16_t _x1, _y1; // Coordinates of top-left corner
   uint16_t _w, _h;
   uint8_t _textsize_x;
   uint8_t _textsize_y;
-  uint16_t _outlinecolor, _fillcolor, _textcolor;
-  char _label[10];
+  uint16_t _outlinecolor, _fillcolor, _textcolor, _pressedcolor;
+  
+  static const int _maxlabellength = 40;
+  char _label[_maxlabellength];
 
   bool currstate, laststate;
 };


### PR DESCRIPTION
This pull request adds functionality to Adafruit_GFX_Button: setting a custom backcolour for when the button is pressed; setting the radius of the rounded corners and fixes an issue with using custom fonts on labels, along with allowing more than 9 characters on a label. The Adafruit_GFX class has been extended to include a getFont() function that exposes the current font.

Adafruit_GFX_Button:
radius property to Adafruit_GFX_Button, to allow buttons to have different sized radius corners. 0 or less results in sharp corners
getLabel() function, exposes the current label.
drawButton can now show a different colour background when the button is pressed.
_pressedcolor field added to hold the background colour of a pressed button..
new overrides to initButton to allow setting of pressedColor.
_maxlabellength used to hold the maximum length of the label - here increased to 40 characters. The property is used in the drawButton function, so changes need making purely to the static const int in the .h file.
drawButton now respects the current font, so the label is positioned correctly.
Adafuit_GFX
getFont() function to get the current font. This allows the Button etc to change behaviour based on the font. e.g. in the Button, we can now better calculate the width of the label correctly and therefore position it better.