### PR TITLE
Dangerous edge case for non-null-terminated string

### DIFF
--- a/Adafruit_GFX.cpp
+++ b/Adafruit_GFX.cpp
@@ -1661,6 +1661,7 @@ void Adafruit_GFX_Button::initButtonUL(Adafruit_GFX *gfx, int16_t x1,
   _textsize_y = textsize_y;
   _gfx = gfx;
   strncpy(_label, label, 9);
+  _label[9] = 0;  // strncpy does not place a null at the end. When 'label' is 9 characters, _label is not terminated.
 }
 
 /**************************************************************************/


### PR DESCRIPTION
strncpy() does not place a null terminator when the max characters is reached of '9' in this case. So, any buttons with 9 or more in the source will wind up with a potentially non-null-terminated _label.