### PR TITLE
Call spi_write_blocking directly for RP2040

### DIFF
--- a/Adafruit_SPITFT.cpp
+++ b/Adafruit_SPITFT.cpp
@@ -1027,10 +1027,12 @@ void Adafruit_SPITFT::writePixels(uint16_t *colors, uint32_t len, bool block,
 
   if (!bigEndian) {
     // switch to 16-bit writes
-    hw_write_masked(&spi_get_hw(pi_spi)->cr0, 15 << SPI_SSPCR0_DSS_LSB, SPI_SSPCR0_DSS_BITS);
+    hw_write_masked(&spi_get_hw(pi_spi)->cr0, 15 << SPI_SSPCR0_DSS_LSB,
+                    SPI_SSPCR0_DSS_BITS);
     spi_write16_blocking(pi_spi, colors, len);
     // switch back to 8-bit
-    hw_write_masked(&spi_get_hw(pi_spi)->cr0, 7 << SPI_SSPCR0_DSS_LSB, SPI_SSPCR0_DSS_BITS);
+    hw_write_masked(&spi_get_hw(pi_spi)->cr0, 7 << SPI_SSPCR0_DSS_LSB,
+                    SPI_SSPCR0_DSS_BITS);
   } else {
     spi_write_blocking(pi_spi, (uint8_t *)colors, len * 2);
   }


### PR DESCRIPTION
Skips some layers and improves performance a lot. Likely overlaps with #343 a bit.

`graphicstest` improvements (62.5MHz):

Benchmark | Time (microseconds) | New time (microseconds) | Change (x)
-- | -- | -- | --
Screen fill | 5120547 | 387943 | 13.2
Text | 259667 | 42504 | 6.1
Lines | 2463232 | 415519 | 5.9
Horiz/Vert Lines | 418902 | 33019 | 12.7
Rectangles (outline) | 266909 | 21791 | 12.2
Rectangles (filled) | 10627497 | 805409 | 13.2
Circles (filled) | 1216044 | 129574 | 9.4
Circles (outline) | 1076740 | 180856 | 6
Triangles (outline) | 560046 | 91170 | 6.1
Triangles (filled) | 3466318 | 293083 | 11.8
Rounded rects (outline) | 510195 | 69136 | 7.4
Rounded rects (filled) | 10571062 | 812290 | 13
Total | 36557159 | 3282294 | 11.1
