### PR TITLE
Faster `writePixels` for ESP8266 with hardware SPI

### DIFF
--- a/Adafruit_SPITFT.cpp
+++ b/Adafruit_SPITFT.cpp
@@ -1011,6 +1011,17 @@ void Adafruit_SPITFT::writePixels(uint16_t *colors, uint32_t len, bool block,
     }
     return;
   }
+#elif defined(ESP8266)
+  if (connection == TFT_HARD_SPI) {
+    if (!bigEndian) {
+      swapBytes(colors, len); // convert little-to-big endian for display
+    }
+    hwspi._spi->writeBytes((uint8_t *)colors, len * 2);
+    if (!bigEndian) {
+      swapBytes(colors, len); // big-to-little endian to restore pixel buffer
+    }
+    return;
+  }
 #elif defined(ARDUINO_NRF52_ADAFRUIT) &&                                       \
     defined(NRF52840_XXAA) // Adafruit nRF52 use SPIM3 DMA at 32Mhz
   if (!bigEndian) {


### PR DESCRIPTION
Similar to what is done for ESP32 and NRF52 chips, use the builtin multi-byte methods for writing pixels over SPI. When reviewing the change, it may be helpful to look at the ESP32 version (immediately above) and the NRF52 version (immediately below)

Unfortunately, there's not a little-endian method in the ESP8266 libs for sending bytes (like `hwspi._spi->writePixels` for ESP32) so instead we need to do in-place byte swaps (similar to what is done for the NRF52 chip).

Even with the `byteSwap` this is _significantly_ faster than the loop.