### PR TITLE
Speed up internal font drawing for opaque background color

### DIFF
--- a/Adafruit_GFX.cpp
+++ b/Adafruit_GFX.cpp
@@ -246,6 +246,36 @@ void Adafruit_GFX::writeFillRect(int16_t x, int16_t y, int16_t w, int16_t h,
 
 /**************************************************************************/
 /*!
+   @brief    set the address window (memory area), overwrite in subclasses if needed
+*/
+/**************************************************************************/
+void Adafruit_GFX::setAddrWindow(unsigned short x, unsigned short y, unsigned short w, unsigned short h)
+{
+  (void)x; (void)y; (void)w; (void)h;
+}
+
+/**************************************************************************/
+/*!
+   @brief    write len pixels of the given color, overwrite in subclasses if needed
+*/
+/**************************************************************************/
+void Adafruit_GFX::writeColor(uint16_t color, uint32_t len)
+{
+ (void)color; (void)len;
+}
+
+/**************************************************************************/
+/*!
+   @brief    write a buffer of pixels, overwrite in subclasses if needed
+*/
+void Adafruit_GFX::writePixels(uint16_t *colors, uint32_t len, bool block,
+                   bool bigEndian)
+{
+  (void)colors; (void)len; (void)block; (void)bigEndian;
+}
+
+/**************************************************************************/
+/*!
    @brief    End a display-writing routine, overwrite in subclasses if
    startWrite is defined!
 */
@@ -1147,28 +1177,41 @@ void Adafruit_GFX::drawChar(int16_t x, int16_t y, unsigned char c,
       c++; // Handle 'classic' charset behavior
 
     startWrite();
-    for (int8_t i = 0; i < 5; i++) { // Char bitmap = 5 columns
-      uint8_t line = pgm_read_byte(&font[c * 5 + i]);
-      for (int8_t j = 0; j < 8; j++, line >>= 1) {
-        if (line & 1) {
-          if (size_x == 1 && size_y == 1)
-            writePixel(x + i, y + j, color);
-          else
-            writeFillRect(x + i * size_x, y + j * size_y, size_x, size_y,
+      if (color != bg) { // faster opaque text
+        setAddrWindow(x, y, 5*size_x, 7*size_y);
+        for (int8_t j = 0; j < 7; j++) { // 7 lines
+            uint8_t uc, ucMask = (1 << j);
+            for (uint8_t k=0; k<size_y; k++) { // repeat size_y lines
+                for (uint8_t i=0; i<5; i++) { // 5 columns
+                    uc = pgm_read_byte(&font[(c * 5) + i]);
+                    writeColor((uc & ucMask) ? color:bg, size_x);
+                } // for each column
+            } // repeat for each line of size_y
+        } // for j
+      } else { // slower text which doesn't overwrite the background color
+        for (int8_t i = 0; i < 5; i++) { // Char bitmap = 5 columns
+          uint8_t line = pgm_read_byte(&font[c * 5 + i]);
+          for (int8_t j = 0; j < 8; j++, line >>= 1) {
+            if (line & 1) {
+              if (size_x == 1 && size_y == 1)
+                writePixel(x + i, y + j, color);
+              else
+                writeFillRect(x + i * size_x, y + j * size_y, size_x, size_y,
                           color);
-        } else if (bg != color) {
-          if (size_x == 1 && size_y == 1)
-            writePixel(x + i, y + j, bg);
-          else
-            writeFillRect(x + i * size_x, y + j * size_y, size_x, size_y, bg);
+            } else if (bg != color) {
+              if (size_x == 1 && size_y == 1)
+                writePixel(x + i, y + j, bg);
+              else
+                writeFillRect(x + i * size_x, y + j * size_y, size_x, size_y, bg);
+            }
+          }
         }
-      }
-    }
-    if (bg != color) { // If opaque, draw vertical line for last column
-      if (size_x == 1 && size_y == 1)
-        writeFastVLine(x + 5, y, 8, bg);
-      else
-        writeFillRect(x + 5 * size_x, y, size_x, 8 * size_y, bg);
+        if (bg != color) { // If opaque, draw vertical line for last column
+          if (size_x == 1 && size_y == 1)
+            writeFastVLine(x + 5, y, 8, bg);
+          else
+            writeFillRect(x + 5 * size_x, y, size_x, 8 * size_y, bg);
+        }
     }
     endWrite();
 

--- a/Adafruit_GFX.cpp
+++ b/Adafruit_GFX.cpp
@@ -246,22 +246,27 @@ void Adafruit_GFX::writeFillRect(int16_t x, int16_t y, int16_t w, int16_t h,
 
 /**************************************************************************/
 /*!
-   @brief    set the address window (memory area), overwrite in subclasses if needed
+   @brief    set the address window (memory area), overwrite in subclasses if
+   needed
 */
 /**************************************************************************/
-void Adafruit_GFX::setAddrWindow(uint16_t x, uint16_t y, uint16_t w, uint16_t h)
-{
-  (void)x; (void)y; (void)w; (void)h;
+void Adafruit_GFX::setAddrWindow(uint16_t x, uint16_t y, uint16_t w,
+                                 uint16_t h) {
+  (void)x;
+  (void)y;
+  (void)w;
+  (void)h;
 }
 
 /**************************************************************************/
 /*!
-   @brief    write len pixels of the given color, overwrite in subclasses if needed
+   @brief    write len pixels of the given color, overwrite in subclasses if
+   needed
 */
 /**************************************************************************/
-void Adafruit_GFX::writeColor(uint16_t color, uint32_t len)
-{
- (void)color; (void)len;
+void Adafruit_GFX::writeColor(uint16_t color, uint32_t len) {
+  (void)color;
+  (void)len;
 }
 
 /**************************************************************************/
@@ -269,9 +274,11 @@ void Adafruit_GFX::writeColor(uint16_t color, uint32_t len)
    @brief    write a buffer of pixels, overwrite in subclasses if needed
 */
 void Adafruit_GFX::writePixels(uint16_t *colors, uint32_t len, bool block,
-                   bool bigEndian)
-{
-  (void)colors; (void)len; (void)block; (void)bigEndian;
+                               bool bigEndian) {
+  (void)colors;
+  (void)len;
+  (void)block;
+  (void)bigEndian;
 }
 /**************************************************************************/
 /*!
@@ -1176,42 +1183,41 @@ void Adafruit_GFX::drawChar(int16_t x, int16_t y, unsigned char c,
       c++; // Handle 'classic' charset behavior
 
     startWrite();
-      if (color != bg) { // faster opaque text
-        setAddrWindow(x, y, 5*size_x, 7*size_y);
-        for (int8_t j = 0; j < 7; j++) { // 7 lines
-            uint8_t uc, ucMask = (1 << j);
-            for (uint8_t k=0; k<size_y; k++) { // repeat size_y lines
-                for (uint8_t i=0; i<5; i++) { // 5 columns
-                    uc = pgm_read_byte(&font[(c * 5) + i]);
-                    writeColor((uc & ucMask) ? color:bg, size_x);
-                } // for each column
-            } // repeat for each line of size_y
-        } // for j
-      } else
-      { // slower text which doesn't overwrite the background color
-        for (int8_t i = 0; i < 5; i++) { // Char bitmap = 5 columns
-          uint8_t line = pgm_read_byte(&font[c * 5 + i]);
-          for (int8_t j = 0; j < 8; j++, line >>= 1) {
-            if (line & 1) {
-              if (size_x == 1 && size_y == 1)
-                writePixel(x + i, y + j, color);
-              else
-                writeFillRect(x + i * size_x, y + j * size_y, size_x, size_y,
-                          color);
-            } else if (bg != color) {
-              if (size_x == 1 && size_y == 1)
-                writePixel(x + i, y + j, bg);
-              else
-                writeFillRect(x + i * size_x, y + j * size_y, size_x, size_y, bg);
-            }
+    if (color != bg) { // faster opaque text
+      setAddrWindow(x, y, 5 * size_x, 7 * size_y);
+      for (int8_t j = 0; j < 7; j++) { // 7 lines
+        uint8_t uc, ucMask = (1 << j);
+        for (uint8_t k = 0; k < size_y; k++) { // repeat size_y lines
+          for (uint8_t i = 0; i < 5; i++) {    // 5 columns
+            uc = pgm_read_byte(&font[(c * 5) + i]);
+            writeColor((uc & ucMask) ? color : bg, size_x);
+          }  // for each column
+        }    // repeat for each line of size_y
+      }      // for j
+    } else { // slower text which doesn't overwrite the background color
+      for (int8_t i = 0; i < 5; i++) { // Char bitmap = 5 columns
+        uint8_t line = pgm_read_byte(&font[c * 5 + i]);
+        for (int8_t j = 0; j < 8; j++, line >>= 1) {
+          if (line & 1) {
+            if (size_x == 1 && size_y == 1)
+              writePixel(x + i, y + j, color);
+            else
+              writeFillRect(x + i * size_x, y + j * size_y, size_x, size_y,
+                            color);
+          } else if (bg != color) {
+            if (size_x == 1 && size_y == 1)
+              writePixel(x + i, y + j, bg);
+            else
+              writeFillRect(x + i * size_x, y + j * size_y, size_x, size_y, bg);
           }
         }
-        if (bg != color) { // If opaque, draw vertical line for last column
-          if (size_x == 1 && size_y == 1)
-            writeFastVLine(x + 5, y, 8, bg);
-          else
-            writeFillRect(x + 5 * size_x, y, size_x, 8 * size_y, bg);
-        }
+      }
+      if (bg != color) { // If opaque, draw vertical line for last column
+        if (size_x == 1 && size_y == 1)
+          writeFastVLine(x + 5, y, 8, bg);
+        else
+          writeFillRect(x + 5 * size_x, y, size_x, 8 * size_y, bg);
+      }
     }
     endWrite();
 

--- a/Adafruit_GFX.cpp
+++ b/Adafruit_GFX.cpp
@@ -244,6 +244,7 @@ void Adafruit_GFX::writeFillRect(int16_t x, int16_t y, int16_t w, int16_t h,
   fillRect(x, y, w, h, color);
 }
 
+#ifndef __AVR__
 /**************************************************************************/
 /*!
    @brief    set the address window (memory area), overwrite in subclasses if needed
@@ -273,7 +274,7 @@ void Adafruit_GFX::writePixels(uint16_t *colors, uint32_t len, bool block,
 {
   (void)colors; (void)len; (void)block; (void)bigEndian;
 }
-
+#endif __AVR__
 /**************************************************************************/
 /*!
    @brief    End a display-writing routine, overwrite in subclasses if

--- a/Adafruit_GFX.cpp
+++ b/Adafruit_GFX.cpp
@@ -1176,7 +1176,6 @@ void Adafruit_GFX::drawChar(int16_t x, int16_t y, unsigned char c,
       c++; // Handle 'classic' charset behavior
 
     startWrite();
-#ifndef __AVR__
       if (color != bg) { // faster opaque text
         setAddrWindow(x, y, 5*size_x, 7*size_y);
         for (int8_t j = 0; j < 7; j++) { // 7 lines
@@ -1189,7 +1188,6 @@ void Adafruit_GFX::drawChar(int16_t x, int16_t y, unsigned char c,
             } // repeat for each line of size_y
         } // for j
       } else
-#endif // __AVR__
       { // slower text which doesn't overwrite the background color
         for (int8_t i = 0; i < 5; i++) { // Char bitmap = 5 columns
           uint8_t line = pgm_read_byte(&font[c * 5 + i]);

--- a/Adafruit_GFX.cpp
+++ b/Adafruit_GFX.cpp
@@ -244,13 +244,12 @@ void Adafruit_GFX::writeFillRect(int16_t x, int16_t y, int16_t w, int16_t h,
   fillRect(x, y, w, h, color);
 }
 
-#ifndef __AVR__
 /**************************************************************************/
 /*!
    @brief    set the address window (memory area), overwrite in subclasses if needed
 */
 /**************************************************************************/
-void Adafruit_GFX::setAddrWindow(unsigned short x, unsigned short y, unsigned short w, unsigned short h)
+void Adafruit_GFX::setAddrWindow(uint16_t x, uint16_t y, uint16_t w, uint16_t h)
 {
   (void)x; (void)y; (void)w; (void)h;
 }
@@ -274,7 +273,6 @@ void Adafruit_GFX::writePixels(uint16_t *colors, uint32_t len, bool block,
 {
   (void)colors; (void)len; (void)block; (void)bigEndian;
 }
-#endif __AVR__
 /**************************************************************************/
 /*!
    @brief    End a display-writing routine, overwrite in subclasses if

--- a/Adafruit_GFX.cpp
+++ b/Adafruit_GFX.cpp
@@ -1177,6 +1177,7 @@ void Adafruit_GFX::drawChar(int16_t x, int16_t y, unsigned char c,
       c++; // Handle 'classic' charset behavior
 
     startWrite();
+#ifndef __AVR__
       if (color != bg) { // faster opaque text
         setAddrWindow(x, y, 5*size_x, 7*size_y);
         for (int8_t j = 0; j < 7; j++) { // 7 lines
@@ -1188,7 +1189,9 @@ void Adafruit_GFX::drawChar(int16_t x, int16_t y, unsigned char c,
                 } // for each column
             } // repeat for each line of size_y
         } // for j
-      } else { // slower text which doesn't overwrite the background color
+      } else
+#endif // __AVR__
+      { // slower text which doesn't overwrite the background color
         for (int8_t i = 0; i < 5; i++) { // Char bitmap = 5 columns
           uint8_t line = pgm_read_byte(&font[c * 5 + i]);
           for (int8_t j = 0; j < 8; j++, line >>= 1) {

--- a/Adafruit_GFX.cpp
+++ b/Adafruit_GFX.cpp
@@ -248,6 +248,10 @@ void Adafruit_GFX::writeFillRect(int16_t x, int16_t y, int16_t w, int16_t h,
 /*!
    @brief    set the address window (memory area), overwrite in subclasses if
    needed
+   @param    x    starting x coordinate
+   @param    y    starting y coordinate
+   @param    w    width in pixels
+   @param    h    height in pixels
 */
 /**************************************************************************/
 void Adafruit_GFX::setAddrWindow(uint16_t x, uint16_t y, uint16_t w,
@@ -262,6 +266,8 @@ void Adafruit_GFX::setAddrWindow(uint16_t x, uint16_t y, uint16_t w,
 /*!
    @brief    write len pixels of the given color, overwrite in subclasses if
    needed
+   @param    color    16-bit 5-6-5 color to write
+   @param    len      number of pixels to write
 */
 /**************************************************************************/
 void Adafruit_GFX::writeColor(uint16_t color, uint32_t len) {
@@ -269,17 +275,6 @@ void Adafruit_GFX::writeColor(uint16_t color, uint32_t len) {
   (void)len;
 }
 
-/**************************************************************************/
-/*!
-   @brief    write a buffer of pixels, overwrite in subclasses if needed
-*/
-void Adafruit_GFX::writePixels(uint16_t *colors, uint32_t len, bool block,
-                               bool bigEndian) {
-  (void)colors;
-  (void)len;
-  (void)block;
-  (void)bigEndian;
-}
 /**************************************************************************/
 /*!
    @brief    End a display-writing routine, overwrite in subclasses if

--- a/Adafruit_GFX.h
+++ b/Adafruit_GFX.h
@@ -35,7 +35,7 @@ public:
   virtual void setAddrWindow(uint16_t x, uint16_t y, uint16_t w, uint16_t h);
   virtual void writeColor(uint16_t color, uint32_t len);
   virtual void writePixels(uint16_t *colors, uint32_t len, bool block,
-                   bool bigEndian);
+                           bool bigEndian);
   virtual void writePixel(int16_t x, int16_t y, uint16_t color);
   virtual void writeFillRect(int16_t x, int16_t y, int16_t w, int16_t h,
                              uint16_t color);

--- a/Adafruit_GFX.h
+++ b/Adafruit_GFX.h
@@ -32,10 +32,12 @@ public:
   // These MAY be overridden by the subclass to provide device-specific
   // optimized code.  Otherwise 'generic' versions are used.
   virtual void startWrite(void);
+#ifndef __AVR__
   virtual void setAddrWindow(uint16_t x, uint16_t y, uint16_t w, uint16_t h);
   virtual void writeColor(uint16_t color, uint32_t len);
   virtual void writePixels(uint16_t *colors, uint32_t len, bool block,
                    bool bigEndian);
+#endif
   virtual void writePixel(int16_t x, int16_t y, uint16_t color);
   virtual void writeFillRect(int16_t x, int16_t y, int16_t w, int16_t h,
                              uint16_t color);

--- a/Adafruit_GFX.h
+++ b/Adafruit_GFX.h
@@ -32,6 +32,10 @@ public:
   // These MAY be overridden by the subclass to provide device-specific
   // optimized code.  Otherwise 'generic' versions are used.
   virtual void startWrite(void);
+  virtual void setAddrWindow(uint16_t x, uint16_t y, uint16_t w, uint16_t h);
+  virtual void writeColor(uint16_t color, uint32_t len);
+  virtual void writePixels(uint16_t *colors, uint32_t len, bool block,
+                   bool bigEndian);
   virtual void writePixel(int16_t x, int16_t y, uint16_t color);
   virtual void writeFillRect(int16_t x, int16_t y, int16_t w, int16_t h,
                              uint16_t color);

--- a/Adafruit_GFX.h
+++ b/Adafruit_GFX.h
@@ -34,8 +34,6 @@ public:
   virtual void startWrite(void);
   virtual void setAddrWindow(uint16_t x, uint16_t y, uint16_t w, uint16_t h);
   virtual void writeColor(uint16_t color, uint32_t len);
-  virtual void writePixels(uint16_t *colors, uint32_t len, bool block,
-                           bool bigEndian);
   virtual void writePixel(int16_t x, int16_t y, uint16_t color);
   virtual void writeFillRect(int16_t x, int16_t y, int16_t w, int16_t h,
                              uint16_t color);

--- a/Adafruit_GFX.h
+++ b/Adafruit_GFX.h
@@ -32,12 +32,10 @@ public:
   // These MAY be overridden by the subclass to provide device-specific
   // optimized code.  Otherwise 'generic' versions are used.
   virtual void startWrite(void);
-#ifndef __AVR__
   virtual void setAddrWindow(uint16_t x, uint16_t y, uint16_t w, uint16_t h);
   virtual void writeColor(uint16_t color, uint32_t len);
   virtual void writePixels(uint16_t *colors, uint32_t len, bool block,
                    bool bigEndian);
-#endif
   virtual void writePixel(int16_t x, int16_t y, uint16_t color);
   virtual void writeFillRect(int16_t x, int16_t y, int16_t w, int16_t h,
                              uint16_t color);


### PR DESCRIPTION
This change adds a few lines of code to the drawChar() function to make it more efficient on TFT displays. For characters with an opaque background color, it's much more efficient to create a single memory window for the whole character and write all the pixels into it than to write small rects for each block of pixels. In an older version of the Adafruit_GFX library that I was working with, this change resulted in a > 9x speedup. In the latest GFX lib, something happened to the writeColor() function that reduced the speedup to less than 2x. Still worth doing, but it would be nice to see what it isn't as fast as it used to be. Here's a photo of my test on an older GFX lib before and after my change.
![adafruit_gfx](https://user-images.githubusercontent.com/9803883/157260598-7dffd795-e627-481a-8422-6be2689e92d2.jpg)

