### PR TITLE
Add bool dmaBusy()

### DIFF
--- a/Adafruit_SPITFT.cpp
+++ b/Adafruit_SPITFT.cpp
@@ -1172,6 +1172,19 @@ void Adafruit_SPITFT::dmaWait(void) {
 }
 
 /*!
+    @brief  Check if DMA transfer is active. Always returts false  if DMA
+            is not enabled.
+*/
+bool Adafruit_SPITFT::dmaBusy(void) const
+{
+#if defined(USE_SPI_DMA) && (defined(__SAMD51__) || defined(ARDUINO_SAMD_ZERO))
+  return dma_busy;
+#else
+  return false;
+#endif
+}
+
+/*!
     @brief  Issue a series of pixels, all the same color. Not self-
             contained; should follow startWrite() and setAddrWindow() calls.
     @param  color  16-bit pixel color in '565' RGB format.

--- a/Adafruit_SPITFT.h
+++ b/Adafruit_SPITFT.h
@@ -234,6 +234,7 @@ public:
   void dmaWait(void);
   // Used by writePixels() in some situations, but might have rare need in
   // user code, so it's public...
+  bool dmaBusy(void) const; // true if DMA is used and busy, false otherwise
   void swapBytes(uint16_t *src, uint32_t len, uint16_t *dest = NULL);
 
   // These functions are similar to the 'write' functions above, but with


### PR DESCRIPTION
Hi!

I’ve added a tiny function called dmaBusy(). It does what is says on the label: it lets the user code know if DMA is actually on and doing something. Maybe there has been a way to know that before, then I’m sorry for being silly, but I couldn’t find it.

Imagine a situation where you might be okay with skipping some frames instead of waiting on DMA. Say you have some kind of reasonably time-critical device (I have a MIDI controller) and there is some not-so-time-critical UI on screen: it’s perfectly good to update a gauge on the next app cycle; or imagine there is a screensaver with some background calculations (say, it’s “Game of Life”): you might do calculation, but skip the rendering. That’s exactly how I use this.

Thank you for the awesome work!