### PR TITLE
Fixing PlatformIO dependency problem

### DIFF
--- a/Adafruit_GFX.h
+++ b/Adafruit_GFX.h
@@ -9,6 +9,9 @@
 #endif
 #include "gfxfont.h"
 
+#include <Adafruit_I2CDevice.h>
+#include <Adafruit_SPIDevice.h>
+
 /// A generic graphics superclass that can handle all sorts of drawing. At a
 /// minimum you can subclass and provide drawPixel(). At a maximum you can do a
 /// ton of overriding to optimize. Used for any/all Adafruit displays!


### PR DESCRIPTION
Fixing the PlatformIO dependency problem mentioned in; https://community.platformio.org/t/adafruit-gfx-lib-will-not-build-any-more-pio-5/15776/12

I fixed this by including the device headers in the Adafruit_GFX.h file, but it could be a braking change for user that doesn't use those libraries in their code. So they might have to download the BusIO library as well.

Please review with caution, I don't know how this change could effect others.
Thanks in advice.