### PR TITLE
fixed missing first line of custom font

### DIFF
--- a/Adafruit_GFX.cpp
+++ b/Adafruit_GFX.cpp
@@ -1179,6 +1179,7 @@ void Adafruit_GFX::drawChar(int16_t x, int16_t y, unsigned char c,
     // drawChar() directly with 'bad' characters of font may cause mayhem!
 
     c -= (uint8_t)pgm_read_byte(&gfxFont->first);
+    uint8_t yAdvance = (uint8_t) pgm_read_byte(&gfxFont->yAdvance);
     GFXglyph *glyph = pgm_read_glyph_ptr(gfxFont, c);
     uint8_t *bitmap = pgm_read_bitmap_ptr(gfxFont);
 
@@ -1220,9 +1221,9 @@ void Adafruit_GFX::drawChar(int16_t x, int16_t y, unsigned char c,
         }
         if (bits & 0x80) {
           if (size_x == 1 && size_y == 1) {
-            writePixel(x + xo + xx, y + yo + yy, color);
+            writePixel(x + xo + xx, y + yo + yy + yAdvance, color);
           } else {
-            writeFillRect(x + (xo16 + xx) * size_x, y + (yo16 + yy) * size_y,
+            writeFillRect(x + (xo16 + xx) * size_x, y + (yo16 + yy) * size_y + yAdvance * size_y,
                           size_x, size_y, color);
           }
         }


### PR DESCRIPTION
The problem: the first line of custom fonts are drawn offscreen (in any size)

The fix: In the drawChar function I've added yAdvance from the custom font construct to the sum of all the data for the y coordinate of the pixel, so that the characters are drawn further down.   

There might be many people out there with work arounds already.