### PR TITLE
Fixed SPI displays work with LGT8fx based boards

### DIFF
--- a/Adafruit_SPITFT.cpp
+++ b/Adafruit_SPITFT.cpp
@@ -1362,7 +1362,7 @@ void Adafruit_SPITFT::writeColor(uint16_t color, uint32_t len) {
       spi_write_blocking(pi_spi, (uint8_t *)&color, 2);
 #else // !ESP8266 && !ARDUINO_ARCH_RP2040
     while (len--) {
-#if defined(__AVR__)
+#if defined(__AVR__) && !defined(__LGT8F__)
       AVR_WRITESPI(hi);
       AVR_WRITESPI(lo);
 #elif defined(ESP32)
@@ -2109,7 +2109,7 @@ inline void Adafruit_SPITFT::SPI_END_TRANSACTION(void) {
 */
 void Adafruit_SPITFT::spiWrite(uint8_t b) {
   if (connection == TFT_HARD_SPI) {
-#if defined(__AVR__)
+#if defined(__AVR__) && !defined(__LGT8F__)
     AVR_WRITESPI(b);
 #elif defined(ESP8266) || defined(ESP32)
     hwspi._spi->write(b);
@@ -2417,7 +2417,7 @@ inline bool Adafruit_SPITFT::SPI_MISO_READ(void) {
 */
 void Adafruit_SPITFT::SPI_WRITE16(uint16_t w) {
   if (connection == TFT_HARD_SPI) {
-#if defined(__AVR__)
+#if defined(__AVR__) && !defined(__LGT8F__)
     AVR_WRITESPI(w >> 8);
     AVR_WRITESPI(w);
 #elif defined(ESP8266) || defined(ESP32)
@@ -2471,7 +2471,7 @@ void Adafruit_SPITFT::SPI_WRITE16(uint16_t w) {
 */
 void Adafruit_SPITFT::SPI_WRITE32(uint32_t l) {
   if (connection == TFT_HARD_SPI) {
-#if defined(__AVR__)
+#if defined(__AVR__) && !defined(__LGT8F__)
     AVR_WRITESPI(l >> 24);
     AVR_WRITESPI(l >> 16);
     AVR_WRITESPI(l >> 8);


### PR DESCRIPTION
Tested with BSP and ILI9341 SPI based display:
* LGT8fx: https://github.com/dbuezas/lgt8fx
* Nulllab: https://github.com/nulllaborg/arduino_nulllab

Issue:
SPI based displays work well with BitBang mode, but does not work with HW SPI.

Root cause:
AVR_WRITESPI() macrosses uses direct access to the HW but LGT8fx has a little bit different implementation. Also, standard implementation sounds like good for default use.

Thank you for creating a pull request to contribute to Adafruit's GitHub code!
Before you open the request please review the following guidelines and tips to
help it be more easily integrated:

- **Describe the scope of your change--i.e. what the change does and what parts
  of the code were modified.**  This will help us understand any risks of integrating
  the code.

- **Describe any known limitations with your change.**  For example if the change
  doesn't apply to a supported platform of the library please mention it.

- **Please run any tests or examples that can exercise your modified code.**  We
  strive to not break users of the code and running tests/examples helps with this
  process.

Thank you again for contributing!  We will try to test and integrate the change
as soon as we can, but be aware we have many GitHub repositories to manage and
can't immediately respond to every request.  There is no need to bump or check in
on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated--sometimes the
priorities of Adafruit's GitHub code (education, ease of use) might not match the
priorities of the pull request.  Don't fret, the open source community thrives on
forks and GitHub makes it easy to keep your changes in a forked repo.

After reviewing the guidelines above you can delete this text from the pull request.
