### PR TITLE
Added getTextBounds() optional arguments xF and yF.

### DIFF
--- a/Adafruit_GFX.h
+++ b/Adafruit_GFX.h
@@ -111,12 +111,15 @@ public:
                 uint16_t bg, uint8_t size);
   void drawChar(int16_t x, int16_t y, unsigned char c, uint16_t color,
                 uint16_t bg, uint8_t size_x, uint8_t size_y);
-  void getTextBounds(const char *string, int16_t x, int16_t y, int16_t *x1,
-                     int16_t *y1, uint16_t *w, uint16_t *h);
+  void getTextBounds(const char *string, int16_t x, int16_t y,
+                     int16_t *xL, int16_t *yT, uint16_t *w, uint16_t *h,
+                     int16_t *xF=NULL, int16_t *yF=NULL);
   void getTextBounds(const __FlashStringHelper *s, int16_t x, int16_t y,
-                     int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h);
-  void getTextBounds(const String &str, int16_t x, int16_t y, int16_t *x1,
-                     int16_t *y1, uint16_t *w, uint16_t *h);
+                     int16_t *xL, int16_t *yT, uint16_t *w, uint16_t *h,
+                     int16_t *xF=NULL, int16_t *yF=NULL);
+  void getTextBounds(const String &str, int16_t x, int16_t y,
+                     int16_t *xL, int16_t *yT, uint16_t *w, uint16_t *h,
+                     int16_t *xF=NULL, int16_t *yF=NULL);
   void setTextSize(uint8_t s);
   void setTextSize(uint8_t sx, uint8_t sy);
   void setFont(const GFXfont *f = NULL);


### PR DESCRIPTION
There are extensive comments in getTextBounds() header in the .cpp file.

The arguments are pointers to places to return values, just like several already-existing arguments to the function. They have default values of NULL, so that if they are not specified in the call, no value is returned for them. Therefore, no change is needed to existing code.

The change applies to all platforms. It has no known limitations.

The reason for this change has to do with the idiosyncrasies of the way the code writes character data to the device. That is accomplished by calling the device setCursor() function to set the position to be written, then calling the device print() function. However, there is no clear relationship between the initial cursor position that is set, and the upper-left (or lower-left) corner of the resulting text boundary box. This is because the font data is specified in a way that allows it to start either slightly left or right of the cursor position, and in addition, the cursor y-position is not necessarily the position of the bottom of the text string, but instead is the position of the text BASELINE, ignoring character DESCENDERS (as on "g" for example).

More directly, the reason for this is that a user of the code might want to JUSTIFY a string, left or right or centered, top or bottom or centered. This cannot be done with the code as it was. The new arguments provide additional information about the size of the text string, that allow it to be properly justified. Previously the function reported the correct string width and height, but it did not report the data needed to set the initial cursor position so that the string would appear where you wanted it.

I tried hard to put in clear comments in the header section of getTextBounds(), but this is such a baffling and obscure issue that I just had to do my best and leave it at that.
