### PR TITLE
Remove volatile from wait loops

### DIFF
--- a/Adafruit_SPITFT.cpp
+++ b/Adafruit_SPITFT.cpp
@@ -2305,10 +2305,6 @@ inline void Adafruit_SPITFT::SPI_MOSI_HIGH(void) {
 #endif // end !HAS_PORT_SET_CLR
 #else  // !USE_FAST_PINIO
   digitalWrite(swspi._mosi, HIGH);
-#if defined(ESP32)
-  for (uint8_t i = 0; i < 1; i++)
-    ;
-#endif // end ESP32
 #endif // end !USE_FAST_PINIO
 }
 
@@ -2328,10 +2324,6 @@ inline void Adafruit_SPITFT::SPI_MOSI_LOW(void) {
 #endif // end !HAS_PORT_SET_CLR
 #else  // !USE_FAST_PINIO
   digitalWrite(swspi._mosi, LOW);
-#if defined(ESP32)
-  for (uint8_t i = 0; i < 1; i++)
-    ;
-#endif // end ESP32
 #endif // end !USE_FAST_PINIO
 }
 
@@ -2345,20 +2337,12 @@ inline void Adafruit_SPITFT::SPI_SCK_HIGH(void) {
   *swspi.sckPortSet = 1;
 #else                                                // !KINETISK
   *swspi.sckPortSet = swspi.sckPinMask;
-#if defined(__IMXRT1052__) || defined(__IMXRT1062__) // Teensy 4.x
-  for (uint8_t i = 0; i < 1; i++)
-    ;
-#endif
 #endif
 #else  // !HAS_PORT_SET_CLR
   *swspi.sckPort |= swspi.sckPinMaskSet;
 #endif // end !HAS_PORT_SET_CLR
 #else  // !USE_FAST_PINIO
   digitalWrite(swspi._sck, HIGH);
-#if defined(ESP32)
-  for (uint8_t i = 0; i < 1; i++)
-    ;
-#endif // end ESP32
 #endif // end !USE_FAST_PINIO
 }
 
@@ -2372,20 +2356,12 @@ inline void Adafruit_SPITFT::SPI_SCK_LOW(void) {
   *swspi.sckPortClr = 1;
 #else                                                // !KINETISK
   *swspi.sckPortClr = swspi.sckPinMask;
-#if defined(__IMXRT1052__) || defined(__IMXRT1062__) // Teensy 4.x
-  for (uint8_t i = 0; i < 1; i++)
-    ;
-#endif
 #endif
 #else  // !HAS_PORT_SET_CLR
   *swspi.sckPort &= swspi.sckPinMaskClr;
 #endif // end !HAS_PORT_SET_CLR
 #else  // !USE_FAST_PINIO
   digitalWrite(swspi._sck, LOW);
-#if defined(ESP32)
-  for (uint8_t i = 0; i < 1; i++)
-    ;
-#endif // end ESP32
 #endif // end !USE_FAST_PINIO
 }
 

--- a/Adafruit_SPITFT.cpp
+++ b/Adafruit_SPITFT.cpp
@@ -2335,7 +2335,7 @@ inline void Adafruit_SPITFT::SPI_SCK_HIGH(void) {
 #if defined(HAS_PORT_SET_CLR)
 #if defined(KINETISK)
   *swspi.sckPortSet = 1;
-#else                                                // !KINETISK
+#else // !KINETISK
   *swspi.sckPortSet = swspi.sckPinMask;
 #endif
 #else  // !HAS_PORT_SET_CLR
@@ -2354,7 +2354,7 @@ inline void Adafruit_SPITFT::SPI_SCK_LOW(void) {
 #if defined(HAS_PORT_SET_CLR)
 #if defined(KINETISK)
   *swspi.sckPortClr = 1;
-#else                                                // !KINETISK
+#else // !KINETISK
   *swspi.sckPortClr = swspi.sckPinMask;
 #endif
 #else  // !HAS_PORT_SET_CLR

--- a/Adafruit_SPITFT.cpp
+++ b/Adafruit_SPITFT.cpp
@@ -2306,7 +2306,7 @@ inline void Adafruit_SPITFT::SPI_MOSI_HIGH(void) {
 #else  // !USE_FAST_PINIO
   digitalWrite(swspi._mosi, HIGH);
 #if defined(ESP32)
-  for (volatile uint8_t i = 0; i < 1; i++)
+  for (uint8_t i = 0; i < 1; i++)
     ;
 #endif // end ESP32
 #endif // end !USE_FAST_PINIO
@@ -2329,7 +2329,7 @@ inline void Adafruit_SPITFT::SPI_MOSI_LOW(void) {
 #else  // !USE_FAST_PINIO
   digitalWrite(swspi._mosi, LOW);
 #if defined(ESP32)
-  for (volatile uint8_t i = 0; i < 1; i++)
+  for (uint8_t i = 0; i < 1; i++)
     ;
 #endif // end ESP32
 #endif // end !USE_FAST_PINIO
@@ -2346,7 +2346,7 @@ inline void Adafruit_SPITFT::SPI_SCK_HIGH(void) {
 #else                                                // !KINETISK
   *swspi.sckPortSet = swspi.sckPinMask;
 #if defined(__IMXRT1052__) || defined(__IMXRT1062__) // Teensy 4.x
-  for (volatile uint8_t i = 0; i < 1; i++)
+  for (uint8_t i = 0; i < 1; i++)
     ;
 #endif
 #endif
@@ -2356,7 +2356,7 @@ inline void Adafruit_SPITFT::SPI_SCK_HIGH(void) {
 #else  // !USE_FAST_PINIO
   digitalWrite(swspi._sck, HIGH);
 #if defined(ESP32)
-  for (volatile uint8_t i = 0; i < 1; i++)
+  for (uint8_t i = 0; i < 1; i++)
     ;
 #endif // end ESP32
 #endif // end !USE_FAST_PINIO
@@ -2373,7 +2373,7 @@ inline void Adafruit_SPITFT::SPI_SCK_LOW(void) {
 #else                                                // !KINETISK
   *swspi.sckPortClr = swspi.sckPinMask;
 #if defined(__IMXRT1052__) || defined(__IMXRT1062__) // Teensy 4.x
-  for (volatile uint8_t i = 0; i < 1; i++)
+  for (uint8_t i = 0; i < 1; i++)
     ;
 #endif
 #endif
@@ -2383,7 +2383,7 @@ inline void Adafruit_SPITFT::SPI_SCK_LOW(void) {
 #else  // !USE_FAST_PINIO
   digitalWrite(swspi._sck, LOW);
 #if defined(ESP32)
-  for (volatile uint8_t i = 0; i < 1; i++)
+  for (uint8_t i = 0; i < 1; i++)
     ;
 #endif // end ESP32
 #endif // end !USE_FAST_PINIO


### PR DESCRIPTION
Removes the `volatile` qualifier being used in a few wait loops. Doesn't seem necessary. This fixes a compile warn for ESP32. Example warn for ref:
```
  /home/runner/Arduino/libraries/Adafruit_GFX_Library/Adafruit_SPITFT.cpp:2309:39: warning: '++' expression of 'volatile'-qualified type is deprecated [-Wvolatile]
   2309 |   for (volatile uint8_t i = 0; i < 1; i++)
        |                                       ^
```