### PR TITLE
Added public methods for button label

### DIFF
--- a/Adafruit_GFX.h
+++ b/Adafruit_GFX.h
@@ -271,6 +271,9 @@ public:
                     uint8_t textsize_y);
   void drawButton(bool inverted = false);
   bool contains(int16_t x, int16_t y);
+  // Public methods to access button label to reuse the Button object.
+  char* getLabel() { return _label;}
+  void setLabel(char* label) {strncpy(_label, label, 9);_label[9]=0;}
 
   /**********************************************************************/
   /*!


### PR DESCRIPTION
  The purpose of this PR is to reuse GFX_button object for On/Off Start/Stop operations
  to save memory and convenience.

  No limitation.

Test:
void loop() {
  button.drawButton(true);//simulated click
  delay(400);
  if(started) {
      button.setLabel("Stop");
      button.drawButton();
  }else {
      button.setLabel("Start");
      button.drawButton();
  }
  Serial.println(button.getLabel());
  started=!started;
  delay(2000);
}

Thank you again for contributing!  We will try to test and integrate the change
as soon as we can, but be aware we have many GitHub repositories to manage and
can't immediately respond to every request.  There is no need to bump or check in
on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated--sometimes the
priorities of Adafruit's GitHub code (education, ease of use) might not match the
priorities of the pull request.  Don't fret, the open source community thrives on
forks and GitHub makes it easy to keep your changes in a forked repo.

After reviewing the guidelines above you can delete this text from the pull request.
