### PR TITLE
BUGFIX: null pointer access violations in Canvas1/8/16 when buffer is not successfully malloc'd

### DIFF
--- a/Adafruit_GFX.cpp
+++ b/Adafruit_GFX.cpp
@@ -2015,6 +2015,10 @@ void GFXcanvas1::drawFastHLine(int16_t x, int16_t y, int16_t w,
 void GFXcanvas1::drawFastRawVLine(int16_t x, int16_t y, int16_t h,
                                   uint16_t color) {
   // x & y already in raw (rotation 0) coordinates, no need to transform.
+  if (!buffer) {
+    return;
+  }
+
   int16_t row_bytes = ((WIDTH + 7) / 8);
   uint8_t *ptr = &buffer[(x / 8) + y * row_bytes];
 
@@ -2053,6 +2057,10 @@ void GFXcanvas1::drawFastRawVLine(int16_t x, int16_t y, int16_t h,
 void GFXcanvas1::drawFastRawHLine(int16_t x, int16_t y, int16_t w,
                                   uint16_t color) {
   // x & y already in raw (rotation 0) coordinates, no need to transform.
+  if (!buffer) {
+    return;
+  }
+
   int16_t rowBytes = ((WIDTH + 7) / 8);
   uint8_t *ptr = &buffer[(x / 8) + y * rowBytes];
   size_t remainingWidthBits = w;
@@ -2351,10 +2359,12 @@ void GFXcanvas8::drawFastHLine(int16_t x, int16_t y, int16_t w,
 void GFXcanvas8::drawFastRawVLine(int16_t x, int16_t y, int16_t h,
                                   uint16_t color) {
   // x & y already in raw (rotation 0) coordinates, no need to transform.
-  uint8_t *buffer_ptr = buffer + y * WIDTH + x;
-  for (int16_t i = 0; i < h; i++) {
-    (*buffer_ptr) = color;
-    buffer_ptr += WIDTH;
+  if (buffer) {
+    uint8_t *buffer_ptr = buffer + y * WIDTH + x;
+    for (int16_t i = 0; i < h; i++) {
+      (*buffer_ptr) = color;
+      buffer_ptr += WIDTH;
+    }
   }
 }
 
@@ -2371,7 +2381,9 @@ void GFXcanvas8::drawFastRawVLine(int16_t x, int16_t y, int16_t h,
 void GFXcanvas8::drawFastRawHLine(int16_t x, int16_t y, int16_t w,
                                   uint16_t color) {
   // x & y already in raw (rotation 0) coordinates, no need to transform.
-  memset(buffer + y * WIDTH + x, color, w);
+  if (buffer) {
+    memset(buffer + y * WIDTH + x, color, w);
+  }
 }
 
 /**************************************************************************/
@@ -2643,10 +2655,12 @@ void GFXcanvas16::drawFastHLine(int16_t x, int16_t y, int16_t w,
 void GFXcanvas16::drawFastRawVLine(int16_t x, int16_t y, int16_t h,
                                    uint16_t color) {
   // x & y already in raw (rotation 0) coordinates, no need to transform.
-  uint16_t *buffer_ptr = buffer + y * WIDTH + x;
-  for (int16_t i = 0; i < h; i++) {
-    (*buffer_ptr) = color;
-    buffer_ptr += WIDTH;
+  if (buffer) {
+    uint16_t *buffer_ptr = buffer + y * WIDTH + x;
+    for (int16_t i = 0; i < h; i++) {
+      (*buffer_ptr) = color;
+      buffer_ptr += WIDTH;
+    }
   }
 }
 
@@ -2662,8 +2676,10 @@ void GFXcanvas16::drawFastRawVLine(int16_t x, int16_t y, int16_t h,
 void GFXcanvas16::drawFastRawHLine(int16_t x, int16_t y, int16_t w,
                                    uint16_t color) {
   // x & y already in raw (rotation 0) coordinates, no need to transform.
-  uint32_t buffer_index = y * WIDTH + x;
-  for (uint32_t i = buffer_index; i < buffer_index + w; i++) {
-    buffer[i] = color;
+  if (buffer) {
+    uint32_t buffer_index = y * WIDTH + x;
+    for (uint32_t i = buffer_index; i < buffer_index + w; i++) {
+      buffer[i] = color;
+    }
   }
 }

--- a/Adafruit_GFX.h
+++ b/Adafruit_GFX.h
@@ -66,6 +66,16 @@ public:
   virtual void drawRect(int16_t x, int16_t y, int16_t w, int16_t h,
                         uint16_t color);
 
+  /************************************************************************/
+  /*!
+    @brief   Query whether the object is fully constructed and ready to use.
+    Subclasses that manage a memory buffer or other properties that may
+    fail to be initialized should override this method.
+    @returns true if the object is ready to use, false otherwise.
+  */
+  /************************************************************************/
+  virtual bool isValid() const { return true; }
+
   // These exist only with Adafruit_GFX (no subclass overrides)
   void drawCircle(int16_t x0, int16_t y0, int16_t r, uint16_t color);
   void drawCircleHelper(int16_t x0, int16_t y0, int16_t r, uint8_t cornername,
@@ -315,6 +325,7 @@ public:
   void fillScreen(uint16_t color);
   void drawFastVLine(int16_t x, int16_t y, int16_t h, uint16_t color);
   void drawFastHLine(int16_t x, int16_t y, int16_t w, uint16_t color);
+  bool isValid() const { return buffer != NULL; }
   bool getPixel(int16_t x, int16_t y) const;
   /**********************************************************************/
   /*!
@@ -346,6 +357,7 @@ public:
   void fillScreen(uint16_t color);
   void drawFastVLine(int16_t x, int16_t y, int16_t h, uint16_t color);
   void drawFastHLine(int16_t x, int16_t y, int16_t w, uint16_t color);
+  bool isValid() const { return buffer != NULL; }
   uint8_t getPixel(int16_t x, int16_t y) const;
   /**********************************************************************/
   /*!
@@ -372,6 +384,7 @@ public:
   void byteSwap(void);
   void drawFastVLine(int16_t x, int16_t y, int16_t h, uint16_t color);
   void drawFastHLine(int16_t x, int16_t y, int16_t w, uint16_t color);
+  bool isValid() const { return buffer != NULL; }
   uint16_t getPixel(int16_t x, int16_t y) const;
   /**********************************************************************/
   /*!

--- a/Adafruit_GFX.h
+++ b/Adafruit_GFX.h
@@ -74,7 +74,7 @@ public:
     @returns true if the object is ready to use, false otherwise.
   */
   /************************************************************************/
-  virtual bool isValid() const { return true; }
+  virtual bool isValid(void) const { return true; }
 
   // These exist only with Adafruit_GFX (no subclass overrides)
   void drawCircle(int16_t x0, int16_t y0, int16_t r, uint16_t color);
@@ -325,7 +325,7 @@ public:
   void fillScreen(uint16_t color);
   void drawFastVLine(int16_t x, int16_t y, int16_t h, uint16_t color);
   void drawFastHLine(int16_t x, int16_t y, int16_t w, uint16_t color);
-  bool isValid() const { return buffer != NULL; }
+  bool isValid(void) const { return buffer != NULL; }
   bool getPixel(int16_t x, int16_t y) const;
   /**********************************************************************/
   /*!
@@ -357,7 +357,7 @@ public:
   void fillScreen(uint16_t color);
   void drawFastVLine(int16_t x, int16_t y, int16_t h, uint16_t color);
   void drawFastHLine(int16_t x, int16_t y, int16_t w, uint16_t color);
-  bool isValid() const { return buffer != NULL; }
+  bool isValid(void) const { return buffer != NULL; }
   uint8_t getPixel(int16_t x, int16_t y) const;
   /**********************************************************************/
   /*!
@@ -384,7 +384,7 @@ public:
   void byteSwap(void);
   void drawFastVLine(int16_t x, int16_t y, int16_t h, uint16_t color);
   void drawFastHLine(int16_t x, int16_t y, int16_t w, uint16_t color);
-  bool isValid() const { return buffer != NULL; }
+  bool isValid(void) const { return buffer != NULL; }
   uint16_t getPixel(int16_t x, int16_t y) const;
   /**********************************************************************/
   /*!


### PR DESCRIPTION
Most of the methods in the `Canvas` classes check that buffer is not null before doing any memory I/O based on its address, but some were overlooked. If `malloc` fails in the constructor, the following methods will result in an access violation:

- `GFXCanvas1::drawFastRawVLine`
- `GFXCanvas1::drawFastRawHLine`
- `GFXcanvas8::drawFastRawVLine`
- `GFXcanvas8::drawFastRawHLine`
- `GFXcanvas16::drawFastRawVLine`
- `GFXcanvas16::drawFastRawHLine`

These methods are called by commonly used methods, such as `fillRect`, so this is a likely scenario. In particular, large displays are problematic; the one I'm using is 800x480, so it is attempting to allocate 800 * 480 * 2 = **768 KB** of RAM, and my poor little ESP32-S3 Feather has around half of that onboard.

With the proposed changes in this PR, the canvas still won't function, obviously, but at least it won't cause boards to spontaneously reset with no clue as to why.

In addition to the above, I have also taken the liberty to add an `isValid` virtual method to `Adafruit_GFX` so that any subclass which manages a frame buffer or other properties that may fail to be initialized properly may implement it. This provides the caller with a viable means of testing whether or not they should even attempt to draw using a given object. I have already implemented it in the `Canvas` classes.

I do realize this may not be received well due to the sheer number of derived classes that `Adafruit_GFX` has, but the default implementation returns true, so subclasses that do not implement it will have zero change in effective behavior (as they already have no way to check if they are usable at runtime).

I reckon that subclasses which should implement it can be dealt with on a case-by-case basis, whenever the opportunity arises in the future.

Thank you for the fantastic libraries and hardware products. Keep 'em coming!