### PR TITLE
add arbitrary rect drawing from bitmaps/canvases (RGB 565, RAM only)

### DIFF
--- a/Adafruit_GFX.cpp
+++ b/Adafruit_GFX.cpp
@@ -1011,6 +1011,37 @@ void Adafruit_GFX::drawRGBBitmap(int16_t x, int16_t y, const uint16_t bitmap[],
 
 /**************************************************************************/
 /*!
+   @brief   Draw a RAM-resident 16-bit image (RGB 5/6/5) or sub-section thereof
+   at the specified (x,y) position, from the specified (src_x,src_y) position.
+   For 16-bit display devices; no color reduction performed.
+    @param    x   Top left corner x coordinate to draw at
+    @param    y   Top left corner y coordinate to draw at
+    @param    bitmap  byte array with 16-bit color bitmap
+    @param    w   Width of the area in the bitmap to draw, in pixels
+    @param    h   Height of the area in the bitmap to draw, in pixels
+    @param    src_x Top left corner x coordinate in the bitmap to read from
+    @param    src_y Top left corner y coordinate in the bitmap to read from
+    @param    src_w Width of the bitmap in pixels. Set to zero if w already
+    contains the bitmap's width.
+*/
+/**************************************************************************/
+void Adafruit_GFX::drawRGBBitmap(int16_t x, int16_t y, uint16_t *bitmap,
+                                 int16_t w, int16_t h, int16_t src_x,
+                                 int16_t src_y, int16_t src_w) {
+  if (src_w == 0)
+    src_w = w;
+
+  startWrite();
+  for (int16_t j = 0; j < h; j++, y++) {
+    for (int16_t i = 0; i < w; i++) {
+      writePixel(x + i, y, bitmap[((j + src_y) * src_w) + src_x + i]);
+    }
+  }
+  endWrite();
+}
+
+/**************************************************************************/
+/*!
    @brief   Draw a RAM-resident 16-bit image (RGB 5/6/5) at the specified (x,y)
    position. For 16-bit display devices; no color reduction performed.
     @param    x   Top left corner x coordinate
@@ -1022,13 +1053,7 @@ void Adafruit_GFX::drawRGBBitmap(int16_t x, int16_t y, const uint16_t bitmap[],
 /**************************************************************************/
 void Adafruit_GFX::drawRGBBitmap(int16_t x, int16_t y, uint16_t *bitmap,
                                  int16_t w, int16_t h) {
-  startWrite();
-  for (int16_t j = 0; j < h; j++, y++) {
-    for (int16_t i = 0; i < w; i++) {
-      writePixel(x + i, y, bitmap[j * w + i]);
-    }
-  }
-  endWrite();
+  drawRGBBitmap(x, y, bitmap, w, h, 0, 0, 0);
 }
 
 /**************************************************************************/

--- a/Adafruit_GFX.h
+++ b/Adafruit_GFX.h
@@ -102,6 +102,8 @@ public:
   void drawRGBBitmap(int16_t x, int16_t y, const uint16_t bitmap[], int16_t w,
                      int16_t h);
   void drawRGBBitmap(int16_t x, int16_t y, uint16_t *bitmap, int16_t w,
+                     int16_t h, int16_t src_x, int16_t src_y, int16_t src_w);
+  void drawRGBBitmap(int16_t x, int16_t y, uint16_t *bitmap, int16_t w,
                      int16_t h);
   void drawRGBBitmap(int16_t x, int16_t y, const uint16_t bitmap[],
                      const uint8_t mask[], int16_t w, int16_t h);

--- a/Adafruit_SPITFT.cpp
+++ b/Adafruit_SPITFT.cpp
@@ -1882,7 +1882,7 @@ void Adafruit_SPITFT::drawRGBBitmap(int16_t x, int16_t y, uint16_t *pcolors,
  */
 void Adafruit_SPITFT::drawRGBBitmap(int16_t x, int16_t y, uint16_t *pcolors,
                                     int16_t w, int16_t h) {
-  drawRGBBitmap(x, y, pcolors, w, h, x, y, w);
+  drawRGBBitmap(x, y, pcolors, w, h, 0, 0, w);
 }
 
 // -------------------------------------------------------------------------

--- a/Adafruit_SPITFT.cpp
+++ b/Adafruit_SPITFT.cpp
@@ -1811,8 +1811,9 @@ void Adafruit_SPITFT::pushColor(uint16_t color) {
 }
 
 /*!
-    @brief  Draw a 16-bit image (565 RGB) at the specified (x,y) position.
-            For 16-bit display devices; no color reduction performed.
+    @brief  Draw a 16-bit image (565 RGB) at the specified (x,y) position from
+            the specified (src_x,src_y). For 16-bit display devices; no color
+            reduction performed.
             Adapted from https://github.com/PaulStoffregen/ILI9341_t3
             by Marc MERLIN. See examples/pictureEmbed to use this.
             5/6/2017: function name and arguments have changed for
@@ -1820,47 +1821,68 @@ void Adafruit_SPITFT::pushColor(uint16_t color) {
             problems in prior implementation.  Formerly drawBitmap() with
             arguments in different order. Handles its own transaction and
             edge clipping/rejection.
-    @param  x        Top left corner horizontal coordinate.
-    @param  y        Top left corner vertical coordinate.
+    @param  x        Top left corner horizontal coordinate to draw at.
+    @param  y        Top left corner vertical coordinate to draw at.
     @param  pcolors  Pointer to 16-bit array of pixel values.
-    @param  w        Width of bitmap in pixels.
-    @param  h        Height of bitmap in pixels.
+    @param  w        Width of the area of the bitmap to draw, in pixels.
+    @param  h        Height of the area of the bitmap to draw, in pixels.
+    @param  src_x    Top left corner horizontal coordinate to read from.
+    @param  src_y    Top left corner vertical coordinate to read from.
+    @param  src_w    Width of the source bitmap in pixels.
 */
 void Adafruit_SPITFT::drawRGBBitmap(int16_t x, int16_t y, uint16_t *pcolors,
-                                    int16_t w, int16_t h) {
-
-  int16_t x2, y2;                 // Lower-right coord
-  if ((x >= _width) ||            // Off-edge right
-      (y >= _height) ||           // " top
-      ((x2 = (x + w - 1)) < 0) || // " left
-      ((y2 = (y + h - 1)) < 0))
+                                    int16_t w, int16_t h, int16_t src_x,
+                                    int16_t src_y, int16_t src_w) {
+  int16_t x2, y2;                  // Lower-right coord
+  if ((x >= _width)             || // Off-edge right
+      (src_x >= src_w)          ||
+      (y >= _height)            || // " bottom
+      ((x2 = (x + w - 1)) < 0)  || // " left
+      (src_x + src_w - 1 < 0)   ||
+      ((y2 = (y + h - 1)) < 0))    // " top
     return; // " bottom
 
-  int16_t bx1 = 0, by1 = 0, // Clipped top-left within bitmap
-      saveW = w;            // Save original bitmap width value
-  if (x < 0) {              // Clip left
+  if (x < 0) { // Clip left
     w += x;
-    bx1 = -x;
     x = 0;
   }
   if (y < 0) { // Clip top
     h += y;
-    by1 = -y;
     y = 0;
   }
+  if (src_x < 0) {
+    src_w += src_x;
+    src_x = -src_x;
+  }
+  if (src_y < 0)
+    src_y = -src_y;
   if (x2 >= _width)
     w = _width - x; // Clip right
   if (y2 >= _height)
     h = _height - y; // Clip bottom
 
-  pcolors += by1 * saveW + bx1; // Offset bitmap ptr to clipped top-left
+  pcolors += (src_y * src_w) + src_x; // Offset bitmap ptr to clipped top-left
   startWrite();
   setAddrWindow(x, y, w, h); // Clipped area
   while (h--) {              // For each (clipped) scanline...
     writePixels(pcolors, w); // Push one (clipped) row
-    pcolors += saveW;        // Advance pointer by one full (unclipped) line
+    pcolors += src_w;        // Advance pointer by one full (unclipped) line
   }
   endWrite();
+}
+
+/*!
+    @brief  Draw a 16-bit image (565 RGB) at the specified (x,y) position.
+            For 16-bit display devices; no color reduction performed.
+    @param  x        Top left corner horizontal coordinate.
+    @param  y        Top left corner vertical coordinate.
+    @param  pcolors  Pointer to 16-bit array of pixel values.
+    @param  w        Width of bitmap in pixels.
+    @param  h        Height of bitmap in pixels.
+ */
+void Adafruit_SPITFT::drawRGBBitmap(int16_t x, int16_t y, uint16_t *pcolors,
+                                    int16_t w, int16_t h) {
+  drawRGBBitmap(x, y, pcolors, w, h, x, y, w);
 }
 
 // -------------------------------------------------------------------------

--- a/Adafruit_SPITFT.h
+++ b/Adafruit_SPITFT.h
@@ -251,6 +251,8 @@ public:
   void pushColor(uint16_t color);
 
   using Adafruit_GFX::drawRGBBitmap; // Check base class first
+  void drawRGBBitmap(int16_t x, int16_t y, uint16_t *bitmap, int16_t w,
+                     int16_t h, int16_t src_x, int16_t src_y, int16_t src_w);
   void drawRGBBitmap(int16_t x, int16_t y, uint16_t *pcolors, int16_t w,
                      int16_t h);
 


### PR DESCRIPTION
For the project I am working on (a compositing window manager which uses Adafruit GFX/Arduino GFX Library as its underlying graphics driver layer), I have the need to draw only certain parts of a memory buffer/canvas containing the pixels to render to the display hardware (using the optimized hardware class' drawing routines).

As far as I can tell, there is currently no way to do that cleanly: I can only do an un-optimized loop and draw individual pixels, or call `Adafruit_SPITFT`'s `setAddrWindow` and `writePixels`, but those are not part of the `Adafruit_GFX` interface _(I may just change my underlying requirement to the SPITFT class instead of the GFX interface if this PR is unwanted)_.

In order to resolve this situation, I:

- Added an additional `drawRGBBitmap` function to `Adafruit_GFX` as well as `Adafruit_SPITFT` _(to utilize its optimized drawing routine)_ that takes the following additional parameters:
  - `src_x` the x offset into the bitmap/canvas to begin reading from
  - `src_y` the y offset ""
  - `src_w` the actual width of the bitmap/canvas (used to move the read pointer forward by a scan line)

- Retrofitted the existing version of `drawRGBBitmap` to simply call the new one with default arguments, resulting in the same behavior as before the change

**Limitations**

- I have only implemented this for the RAM-resident RGB 565 routines. If you guys are keen on taking the change, I would be glad to do the others as well, but this is the only one I need for now.

I tested to make sure that the existing interface works as expected when calling with 0,0 for x,y and the bitmap's width and height, but I did not test edge cases like negative x,y or invalid width/height values. I did the best I could to mimic the logic that was already in place.

If more formal testing and proof that I didn't break anything is required, let me know and I will write something up.
