### PR TITLE
Faster char write

### DIFF
--- a/Adafruit_GFX.cpp
+++ b/Adafruit_GFX.cpp
@@ -1147,31 +1147,30 @@ void Adafruit_GFX::drawChar(int16_t x, int16_t y, unsigned char c,
       c++; // Handle 'classic' charset behavior
 
     startWrite();
-    int8_t rp, rb;//Count sequential FG and BG pixels in column 
-    for (int8_t i = 0; i < 5; i++, rp=0, rb=0) { // Char bitmap = 5 columns
+    int8_t rp, rb; // Count sequential FG and BG pixels in column
+    for (int8_t i = 0; i < 5; i++, rp = 0, rb = 0) { // Char bitmap = 5 columns
       uint8_t line = pgm_read_byte(&font[c * 5 + i]);
       for (int8_t j = 0; j < 8; j++, line >>= 1) {
         if (line & 1) {
           rp++;
-          if (!(1 & (line >> 1))) { //write sequential pixels with writeFillRect
-            if(rp == 1 && size_x == 1 && size_y == 1) {
+          if (!(1 & (line >> 1)) ||
+              j == 7) { // write sequential pixels with writeFillRect
+            if (rp == 1 && size_x == 1 && size_y == 1) {
               writePixel(x + i, y + j, color);
-            }
-            else if(rp > 0) {
-              writeFillRect(x + i * size_x, y + (j - (rp -1)) * size_y, size_x,
+            } else if (rp > 0) {
+              writeFillRect(x + i * size_x, y + (j - (rp - 1)) * size_y, size_x,
                             size_y * rp, color);
             }
             rp = 0;
           }
-        } 
-        else if (bg != color) {
+        } else if (bg != color) {
           rb++;
-          if( 1 & (line >> 1)) { //write sequential pixels with writeFillRect
+          if (1 & (line >> 1) ||
+              j == 7) { // write sequential pixels with writeFillRect
             if (rb == 1 && size_x == 1 && size_y == 1) {
               writePixel(x + i, y + j, bg);
-            }
-            else if(rb > 0) {
-              writeFillRect(x + i * size_x, y + (j - (rb -1)) * size_y, size_x,
+            } else if (rb > 0) {
+              writeFillRect(x + i * size_x, y + (j - (rb - 1)) * size_y, size_x,
                             size_y * rb, bg);
             }
             rb = 0;

--- a/Adafruit_GFX.cpp
+++ b/Adafruit_GFX.cpp
@@ -1147,20 +1147,35 @@ void Adafruit_GFX::drawChar(int16_t x, int16_t y, unsigned char c,
       c++; // Handle 'classic' charset behavior
 
     startWrite();
-    for (int8_t i = 0; i < 5; i++) { // Char bitmap = 5 columns
+    int8_t rp, rb;//Count sequential FG and BG pixels in column 
+    for (int8_t i = 0; i < 5; i++, rp=0, rb=0) { // Char bitmap = 5 columns
       uint8_t line = pgm_read_byte(&font[c * 5 + i]);
       for (int8_t j = 0; j < 8; j++, line >>= 1) {
         if (line & 1) {
-          if (size_x == 1 && size_y == 1)
-            writePixel(x + i, y + j, color);
-          else
-            writeFillRect(x + i * size_x, y + j * size_y, size_x, size_y,
-                          color);
-        } else if (bg != color) {
-          if (size_x == 1 && size_y == 1)
-            writePixel(x + i, y + j, bg);
-          else
-            writeFillRect(x + i * size_x, y + j * size_y, size_x, size_y, bg);
+          rp++;
+          if (!(1 & (line >> 1))) { //write sequential pixels with writeFillRect
+            if(rp == 1 && size_x == 1 && size_y == 1) {
+              writePixel(x + i, y + j, color);
+            }
+            else if(rp > 0) {
+              writeFillRect(x + i * size_x, y + (j - (rp -1)) * size_y, size_x,
+                            size_y * rp, color);
+            }
+            rp = 0;
+          }
+        } 
+        else if (bg != color) {
+          rb++;
+          if( 1 & (line >> 1)) { //write sequential pixels with writeFillRect
+            if (rb == 1 && size_x == 1 && size_y == 1) {
+              writePixel(x + i, y + j, bg);
+            }
+            else if(rb > 0) {
+              writeFillRect(x + i * size_x, y + (j - (rb -1)) * size_y, size_x,
+                            size_y * rb, bg);
+            }
+            rb = 0;
+          }
         }
       }
     }

--- a/Adafruit_GFX.h
+++ b/Adafruit_GFX.h
@@ -298,7 +298,8 @@ protected:
   Adafruit_GFX *_gfx;     ///< gfx display pointer
   int16_t _x1;            ///< x Coordinate of top-left corner
   int16_t _y1;            ///< y Coordinate of top-left corner
-  uint16_t _w, _h;        ///< width and heaight of button
+  uint16_t _w;            ///< width of button
+  uint16_t _h;            ///< height of button
   uint8_t _textsize_x;    ///< width of text character in pixels
   uint8_t _textsize_y;    ///< height of text character in pixels
   uint16_t _outlinecolor; ///< button outline color
@@ -306,7 +307,8 @@ protected:
   uint16_t _textcolor;    ///< text color
   char _label[10];        ///< text label on button
 
-  bool currstate, laststate;
+  bool currstate; ///< current pressed state
+  bool laststate; ///< previous pressed state
 };
 
 /// A GFX 1-bit canvas context for graphics

--- a/Adafruit_GFX.h
+++ b/Adafruit_GFX.h
@@ -294,7 +294,7 @@ public:
   /**********************************************************************/
   bool isPressed(void) { return currstate; };
 
-private:
+protected:
   Adafruit_GFX *_gfx;
   int16_t _x1, _y1; // Coordinates of top-left corner
   uint16_t _w, _h;

--- a/Adafruit_GFX.h
+++ b/Adafruit_GFX.h
@@ -295,13 +295,16 @@ public:
   bool isPressed(void) { return currstate; };
 
 protected:
-  Adafruit_GFX *_gfx;
-  int16_t _x1, _y1; // Coordinates of top-left corner
-  uint16_t _w, _h;
-  uint8_t _textsize_x;
-  uint8_t _textsize_y;
-  uint16_t _outlinecolor, _fillcolor, _textcolor;
-  char _label[10];
+  Adafruit_GFX *_gfx;     ///< gfx display pointer
+  int16_t _x1;            ///< x Coordinate of top-left corner
+  int16_t _y1;            ///< y Coordinate of top-left corner
+  uint16_t _w, _h;        ///< width and heaight of button
+  uint8_t _textsize_x;    ///< width of text character in pixels
+  uint8_t _textsize_y;    ///< height of text character in pixels
+  uint16_t _outlinecolor; ///< button outline color
+  uint16_t _fillcolor;    ///< button fill color
+  uint16_t _textcolor;    ///< text color
+  char _label[10];        ///< text label on button
 
   bool currstate, laststate;
 };


### PR DESCRIPTION

[Sped up char writing with built in font by grouping pixels in column of character map then using writeFillRect() for less spi overhead.  With transparent background this speeds up line write speed by about half, with non-transparent background it's about 3 times faster.