### PR TITLE
Fix broken reset logic if reset pin exceeds 127 due to int8 overflow

### DIFF
--- a/Adafruit_GrayOLED.cpp
+++ b/Adafruit_GrayOLED.cpp
@@ -61,7 +61,7 @@
             allocation is performed there!
 */
 Adafruit_GrayOLED::Adafruit_GrayOLED(uint8_t bpp, uint16_t w, uint16_t h,
-                                     TwoWire *twi, int8_t rst_pin,
+                                     TwoWire *twi, int16_t rst_pin,
                                      uint32_t clkDuring, uint32_t clkAfter)
     : Adafruit_GFX(w, h), i2c_preclk(clkDuring), i2c_postclk(clkAfter),
       buffer(NULL), dcPin(-1), csPin(-1), rstPin(rst_pin), _bpp(bpp) {
@@ -97,9 +97,9 @@ Adafruit_GrayOLED::Adafruit_GrayOLED(uint8_t bpp, uint16_t w, uint16_t h,
             allocation is performed there!
 */
 Adafruit_GrayOLED::Adafruit_GrayOLED(uint8_t bpp, uint16_t w, uint16_t h,
-                                     int8_t mosi_pin, int8_t sclk_pin,
-                                     int8_t dc_pin, int8_t rst_pin,
-                                     int8_t cs_pin)
+                                     int16_t mosi_pin, int16_t sclk_pin,
+                                     int16_t dc_pin, int16_t rst_pin,
+                                     int16_t cs_pin)
     : Adafruit_GFX(w, h), dcPin(dc_pin), csPin(cs_pin), rstPin(rst_pin),
       _bpp(bpp) {
 
@@ -133,8 +133,8 @@ Adafruit_GrayOLED::Adafruit_GrayOLED(uint8_t bpp, uint16_t w, uint16_t h,
             allocation is performed there!
 */
 Adafruit_GrayOLED::Adafruit_GrayOLED(uint8_t bpp, uint16_t w, uint16_t h,
-                                     SPIClass *spi, int8_t dc_pin,
-                                     int8_t rst_pin, int8_t cs_pin,
+                                     SPIClass *spi, int16_t dc_pin,
+                                     int16_t rst_pin, int16_t cs_pin,
                                      uint32_t bitrate)
     : Adafruit_GFX(w, h), dcPin(dc_pin), csPin(cs_pin), rstPin(rst_pin),
       _bpp(bpp) {

--- a/Adafruit_GrayOLED.h
+++ b/Adafruit_GrayOLED.h
@@ -47,13 +47,13 @@
 class Adafruit_GrayOLED : public Adafruit_GFX {
 public:
   Adafruit_GrayOLED(uint8_t bpp, uint16_t w, uint16_t h, TwoWire *twi = &Wire,
-                    int8_t rst_pin = -1, uint32_t preclk = 400000,
+                    int16_t rst_pin = -1, uint32_t preclk = 400000,
                     uint32_t postclk = 100000);
-  Adafruit_GrayOLED(uint8_t bpp, uint16_t w, uint16_t h, int8_t mosi_pin,
-                    int8_t sclk_pin, int8_t dc_pin, int8_t rst_pin,
-                    int8_t cs_pin);
+  Adafruit_GrayOLED(uint8_t bpp, uint16_t w, uint16_t h, int16_t mosi_pin,
+                    int16_t sclk_pin, int16_t dc_pin, int16_t rst_pin,
+                    int16_t cs_pin);
   Adafruit_GrayOLED(uint8_t bpp, uint16_t w, uint16_t h, SPIClass *spi,
-                    int8_t dc_pin, int8_t rst_pin, int8_t cs_pin,
+                    int16_t dc_pin, int16_t rst_pin, int16_t cs_pin,
                     uint32_t bitrate = 8000000UL);
 
   ~Adafruit_GrayOLED(void);


### PR DESCRIPTION
This is in conjunction with adafruit/Adafruit_SH110x#20
