### PR TITLE
Enable STM32 fastio for softspi

### DIFF
--- a/Adafruit_SPITFT.cpp
+++ b/Adafruit_SPITFT.cpp
@@ -124,7 +124,7 @@ Adafruit_SPITFT::Adafruit_SPITFT(uint16_t w, uint16_t h, int8_t cs, int8_t dc,
   swspi._miso = miso;
 #if defined(USE_FAST_PINIO)
 #if defined(HAS_PORT_SET_CLR)
-#if defined(CORE_TEENSY)
+#if defined(CORE_TEENSY) || defined(STM32_CORE_VERSION)
 #if !defined(KINETISK)
   dcPinMask = digitalPinToBitMask(dc);
   swspi.sckPinMask = digitalPinToBitMask(sck);
@@ -157,7 +157,7 @@ Adafruit_SPITFT::Adafruit_SPITFT(uint16_t w, uint16_t h, int8_t cs, int8_t dc,
   } else {
     swspi.misoPort = portInputRegister(digitalPinToPort(dc));
   }
-#else  // !CORE_TEENSY
+#else  // !CORE_TEENSY && !STM32_CORE_VERSION
   dcPinMask = digitalPinToBitMask(dc);
   swspi.sckPinMask = digitalPinToBitMask(sck);
   swspi.mosiPinMask = digitalPinToBitMask(mosi);
@@ -187,7 +187,7 @@ Adafruit_SPITFT::Adafruit_SPITFT(uint16_t w, uint16_t h, int8_t cs, int8_t dc,
     swspi.misoPinMask = 0;
     swspi.misoPort = (PORTreg_t)portInputRegister(digitalPinToPort(dc));
   }
-#endif // end !CORE_TEENSY
+#endif // end !CORE_TEENSY && !STM32_CORE_VERSION
 #else  // !HAS_PORT_SET_CLR
   dcPort = (PORTreg_t)portOutputRegister(digitalPinToPort(dc));
   dcPinMaskSet = digitalPinToBitMask(dc);
@@ -285,7 +285,7 @@ Adafruit_SPITFT::Adafruit_SPITFT(uint16_t w, uint16_t h, SPIClass *spiClass,
   hwspi._spi = spiClass;
 #if defined(USE_FAST_PINIO)
 #if defined(HAS_PORT_SET_CLR)
-#if defined(CORE_TEENSY)
+#if defined(CORE_TEENSY) || defined(STM32_CORE_VERSION)
 #if !defined(KINETISK)
   dcPinMask = digitalPinToBitMask(dc);
 #endif
@@ -304,7 +304,7 @@ Adafruit_SPITFT::Adafruit_SPITFT(uint16_t w, uint16_t h, SPIClass *spiClass,
     csPortSet = dcPortSet;
     csPortClr = dcPortClr;
   }
-#else  // !CORE_TEENSY
+#else  // !CORE_TEENSY && !STM32_CORE_VERSION
   dcPinMask = digitalPinToBitMask(dc);
   dcPortSet = &(PORT->Group[g_APinDescription[dc].ulPort].OUTSET.reg);
   dcPortClr = &(PORT->Group[g_APinDescription[dc].ulPort].OUTCLR.reg);
@@ -321,7 +321,7 @@ Adafruit_SPITFT::Adafruit_SPITFT(uint16_t w, uint16_t h, SPIClass *spiClass,
     csPortClr = dcPortClr;
     csPinMask = 0;
   }
-#endif // end !CORE_TEENSY
+#endif // end !CORE_TEENSY && !STM32_CORE_VERSION
 #else  // !HAS_PORT_SET_CLR
   dcPort = (PORTreg_t)portOutputRegister(digitalPinToPort(dc));
   dcPinMaskSet = digitalPinToBitMask(dc);
@@ -385,7 +385,7 @@ Adafruit_SPITFT::Adafruit_SPITFT(uint16_t w, uint16_t h, tftBusWidth busWidth,
   tft8.wide = (busWidth == tft16bitbus);
 #if defined(USE_FAST_PINIO)
 #if defined(HAS_PORT_SET_CLR)
-#if defined(CORE_TEENSY)
+#if defined(CORE_TEENSY) || defined(STM32_CORE_VERSION)
   tft8.wrPortSet = portSetRegister(digitalPinToPort(wr));
   tft8.wrPortClr = portClearRegister(digitalPinToPort(wr));
 #if !defined(KINETISK)
@@ -425,7 +425,7 @@ Adafruit_SPITFT::Adafruit_SPITFT(uint16_t w, uint16_t h, tftBusWidth busWidth,
   tft8.readPort = portInputRegister(digitalPinToPort(d0));
   tft8.dirSet = portModeRegister(digitalPinToPort(d0));
   tft8.dirClr = portModeRegister(digitalPinToPort(d0));
-#else  // !CORE_TEENSY
+#else  // !CORE_TEENSY && !STM32_CORE_VERSION
   tft8.wrPinMask = digitalPinToBitMask(wr);
   tft8.wrPortSet = &(PORT->Group[g_APinDescription[wr].ulPort].OUTSET.reg);
   tft8.wrPortClr = &(PORT->Group[g_APinDescription[wr].ulPort].OUTCLR.reg);
@@ -466,7 +466,7 @@ Adafruit_SPITFT::Adafruit_SPITFT(uint16_t w, uint16_t h, tftBusWidth busWidth,
   tft8.readPort = (volatile uint8_t *)&(p->IN.reg) + offset;
   tft8.dirSet = (volatile uint8_t *)&(p->DIRSET.reg) + offset;
   tft8.dirClr = (volatile uint8_t *)&(p->DIRCLR.reg) + offset;
-#endif // end !CORE_TEENSY
+#endif // end !CORE_TEENSY && !STM32_CORE_VERSION
 #else  // !HAS_PORT_SET_CLR
   tft8.wrPort = (PORTreg_t)portOutputRegister(digitalPinToPort(wr));
   tft8.wrPinMaskSet = digitalPinToBitMask(wr);
@@ -608,7 +608,7 @@ void Adafruit_SPITFT::initSPI(uint32_t freq, uint8_t spiMode) {
       }
     }
 #elif defined(USE_FAST_PINIO)
-#if defined(CORE_TEENSY)
+#if defined(CORE_TEENSY) || defined(STM32_CORE_VERSION)
     if (!tft8.wide) {
       *tft8.dirSet = 0xFF;    // Set port to output
       *tft8.writePort = 0x00; // Write all 0s
@@ -616,7 +616,7 @@ void Adafruit_SPITFT::initSPI(uint32_t freq, uint8_t spiMode) {
       *(volatile uint16_t *)tft8.dirSet = 0xFFFF;
       *(volatile uint16_t *)tft8.writePort = 0x0000;
     }
-#else  // !CORE_TEENSY
+#else  // !CORE_TEENSY && !STM32_CORE_VERSION
     uint8_t portNum = g_APinDescription[tft8._d0].ulPort, // d0 PORT #
         dBit = g_APinDescription[tft8._d0].ulPin,         // d0 bit in PORT
         lastBit = dBit + (tft8.wide ? 15 : 7);
@@ -628,7 +628,7 @@ void Adafruit_SPITFT::initSPI(uint32_t freq, uint8_t spiMode) {
         digitalWrite(i, LOW);
       }
     }
-#endif // end !CORE_TEENSY
+#endif // end !CORE_TEENSY && !STM32_CORE_VERSION
 #endif
     pinMode(tft8._wr, OUTPUT);
     digitalWrite(tft8._wr, HIGH);

--- a/Adafruit_SPITFT.cpp
+++ b/Adafruit_SPITFT.cpp
@@ -130,18 +130,18 @@ Adafruit_SPITFT::Adafruit_SPITFT(uint16_t w, uint16_t h, int8_t cs, int8_t dc,
   swspi.sckPinMask = digitalPinToBitMask(sck);
   swspi.mosiPinMask = digitalPinToBitMask(mosi);
 #endif
-  dcPortSet = portSetRegister(dc);
-  dcPortClr = portClearRegister(dc);
-  swspi.sckPortSet = portSetRegister(sck);
-  swspi.sckPortClr = portClearRegister(sck);
-  swspi.mosiPortSet = portSetRegister(mosi);
-  swspi.mosiPortClr = portClearRegister(mosi);
+  dcPortSet = portSetRegister(digitalPinToPort(dc));
+  dcPortClr = portClearRegister(digitalPinToPort(dc));
+  swspi.sckPortSet = portSetRegister(digitalPinToPort(sck));
+  swspi.sckPortClr = portClearRegister(digitalPinToPort(sck));
+  swspi.mosiPortSet = portSetRegister(digitalPinToPort(mosi));
+  swspi.mosiPortClr = portClearRegister(digitalPinToPort(mosi));
   if (cs >= 0) {
 #if !defined(KINETISK)
     csPinMask = digitalPinToBitMask(cs);
 #endif
-    csPortSet = portSetRegister(cs);
-    csPortClr = portClearRegister(cs);
+    csPortSet = portSetRegister(digitalPinToPort(cs));
+    csPortClr = portClearRegister(digitalPinToPort(cs));
   } else {
 #if !defined(KINETISK)
     csPinMask = 0;
@@ -150,12 +150,12 @@ Adafruit_SPITFT::Adafruit_SPITFT(uint16_t w, uint16_t h, int8_t cs, int8_t dc,
     csPortClr = dcPortClr;
   }
   if (miso >= 0) {
-    swspi.misoPort = portInputRegister(miso);
+    swspi.misoPort = portInputRegister(digitalPinToPort(miso));
 #if !defined(KINETISK)
     swspi.misoPinMask = digitalPinToBitMask(miso);
 #endif
   } else {
-    swspi.misoPort = portInputRegister(dc);
+    swspi.misoPort = portInputRegister(digitalPinToPort(dc));
   }
 #else  // !CORE_TEENSY
   dcPinMask = digitalPinToBitMask(dc);
@@ -289,14 +289,14 @@ Adafruit_SPITFT::Adafruit_SPITFT(uint16_t w, uint16_t h, SPIClass *spiClass,
 #if !defined(KINETISK)
   dcPinMask = digitalPinToBitMask(dc);
 #endif
-  dcPortSet = portSetRegister(dc);
-  dcPortClr = portClearRegister(dc);
+  dcPortSet = portSetRegister(digitalPinToPort(dc));
+  dcPortClr = portClearRegister(digitalPinToPort(dc));
   if (cs >= 0) {
 #if !defined(KINETISK)
     csPinMask = digitalPinToBitMask(cs);
 #endif
-    csPortSet = portSetRegister(cs);
-    csPortClr = portClearRegister(cs);
+    csPortSet = portSetRegister(digitalPinToPort(cs));
+    csPortClr = portClearRegister(digitalPinToPort(cs));
   } else { // see comments below
 #if !defined(KINETISK)
     csPinMask = 0;
@@ -386,19 +386,19 @@ Adafruit_SPITFT::Adafruit_SPITFT(uint16_t w, uint16_t h, tftBusWidth busWidth,
 #if defined(USE_FAST_PINIO)
 #if defined(HAS_PORT_SET_CLR)
 #if defined(CORE_TEENSY)
-  tft8.wrPortSet = portSetRegister(wr);
-  tft8.wrPortClr = portClearRegister(wr);
+  tft8.wrPortSet = portSetRegister(digitalPinToPort(wr));
+  tft8.wrPortClr = portClearRegister(digitalPinToPort(wr));
 #if !defined(KINETISK)
   dcPinMask = digitalPinToBitMask(dc);
 #endif
-  dcPortSet = portSetRegister(dc);
-  dcPortClr = portClearRegister(dc);
+  dcPortSet = portSetRegister(digitalPinToPort(dc));
+  dcPortClr = portClearRegister(digitalPinToPort(dc));
   if (cs >= 0) {
 #if !defined(KINETISK)
     csPinMask = digitalPinToBitMask(cs);
 #endif
-    csPortSet = portSetRegister(cs);
-    csPortClr = portClearRegister(cs);
+    csPortSet = portSetRegister(digitalPinToPort(cs));
+    csPortClr = portClearRegister(digitalPinToPort(cs));
   } else { // see comments below
 #if !defined(KINETISK)
     csPinMask = 0;
@@ -412,8 +412,8 @@ Adafruit_SPITFT::Adafruit_SPITFT(uint16_t w, uint16_t h, tftBusWidth busWidth,
 #else // !KINETISK
     tft8.rdPinMask = digitalPinToBitMask(rd);
 #endif
-    tft8.rdPortSet = portSetRegister(rd);
-    tft8.rdPortClr = portClearRegister(rd);
+    tft8.rdPortSet = portSetRegister(digitalPinToPort(rd));
+    tft8.rdPortClr = portClearRegister(digitalPinToPort(rd));
   } else {
     tft8.rdPinMask = 0;
     tft8.rdPortSet = dcPortSet;
@@ -421,10 +421,10 @@ Adafruit_SPITFT::Adafruit_SPITFT(uint16_t w, uint16_t h, tftBusWidth busWidth,
   }
   // These are all uint8_t* pointers -- elsewhere they're recast
   // as necessary if a 'wide' 16-bit interface is in use.
-  tft8.writePort = portOutputRegister(d0);
-  tft8.readPort = portInputRegister(d0);
-  tft8.dirSet = portModeRegister(d0);
-  tft8.dirClr = portModeRegister(d0);
+  tft8.writePort = portOutputRegister(digitalPinToPort(d0));
+  tft8.readPort = portInputRegister(digitalPinToPort(d0));
+  tft8.dirSet = portModeRegister(digitalPinToPort(d0));
+  tft8.dirClr = portModeRegister(digitalPinToPort(d0));
 #else  // !CORE_TEENSY
   tft8.wrPinMask = digitalPinToBitMask(wr);
   tft8.wrPortSet = &(PORT->Group[g_APinDescription[wr].ulPort].OUTSET.reg);

--- a/Adafruit_SPITFT.h
+++ b/Adafruit_SPITFT.h
@@ -49,6 +49,10 @@ typedef uint8_t ADAGFX_PORT_t; ///< PORT values are 8-bit
 #endif
 #define USE_FAST_PINIO   ///< Use direct PORT register access
 #define HAS_PORT_SET_CLR ///< PORTs have set & clear registers
+#elif defined(STM32_CORE_VERSION)
+typedef uint32_t ADAGFX_PORT_t;
+#define USE_FAST_PINIO   ///< Use direct PORT register access
+#define HAS_PORT_SET_CLR ///< PORTs have set & clear registers
 #else
 // Arduino Due?
 typedef uint32_t ADAGFX_PORT_t; ///< PORT values are 32-bit
@@ -442,24 +446,11 @@ protected:
     } swspi;                     ///< Software SPI values
     struct {                     //   Values specific to 8-bit parallel:
 #if defined(USE_FAST_PINIO)
-
-#if defined(__IMXRT1052__) || defined(__IMXRT1062__) // Teensy 4.x
-      volatile uint32_t *writePort; ///< PORT register for DATA WRITE
-      volatile uint32_t *readPort;  ///< PORT (PIN) register for DATA READ
-#else
-      volatile uint8_t *writePort;  ///< PORT register for DATA WRITE
-      volatile uint8_t *readPort;   ///< PORT (PIN) register for DATA READ
-#endif
+      PORTreg_t writePort;  ///< PORT register for DATA WRITE
+      PORTreg_t readPort;   ///< PORT (PIN) register for DATA READ
 #if defined(HAS_PORT_SET_CLR)
-      // Port direction register pointers are always 8-bit regardless of
-      // PORTreg_t -- even if 32-bit port, we modify a byte-aligned 8 bits.
-#if defined(__IMXRT1052__) || defined(__IMXRT1062__) // Teensy 4.x
-      volatile uint32_t *dirSet; ///< PORT byte data direction SET
-      volatile uint32_t *dirClr; ///< PORT byte data direction CLEAR
-#else
-      volatile uint8_t *dirSet; ///< PORT byte data direction SET
-      volatile uint8_t *dirClr; ///< PORT byte data direction CLEAR
-#endif
+      PORTreg_t dirSet; ///< PORT byte data direction SET
+      PORTreg_t dirClr; ///< PORT byte data direction CLEAR
       PORTreg_t wrPortSet; ///< PORT register for write strobe SET
       PORTreg_t wrPortClr; ///< PORT register for write strobe CLEAR
       PORTreg_t rdPortSet; ///< PORT register for read strobe SET
@@ -469,9 +460,7 @@ protected:
 #endif                         // end !KINETISK
       ADAGFX_PORT_t rdPinMask; ///< Bitmask for read strobe
 #else                          // !HAS_PORT_SET_CLR
-      // Port direction register pointer is always 8-bit regardless of
-      // PORTreg_t -- even if 32-bit port, we modify a byte-aligned 8 bits.
-      volatile uint8_t *portDir;  ///< PORT direction register
+      PORTreg_t portDir;          ///< PORT direction register
       PORTreg_t wrPort;           ///< PORT register for write strobe
       PORTreg_t rdPort;           ///< PORT register for read strobe
       ADAGFX_PORT_t wrPinMaskSet; ///< Bitmask for write strobe SET (OR)


### PR DESCRIPTION
There was a `digitalPinToPort` macro usage missing in softspi fastio implementation for Teensy, that worked by accident, only because Teensy implementation of this macro is trivial: `#define digitalPinToPort(pin)    (pin)`. After that Teensy fastio implementation becomes pretty cross platform, so I enabled STM32 as a consumer of it.

Also did some `PORTreg_t` cleanup, because comments were contradicting the code, but I don't have hardware to test it on different platforms.
I mean this comment specifically:
```
      // Port direction register pointers are always 8-bit regardless of
      // PORTreg_t -- even if 32-bit port, we modify a byte-aligned 8 bits.
```
[Here](https://github.com/adafruit/Adafruit-GFX-Library/compare/master...omicronns:Adafruit-GFX-Library:master?expand=1#diff-20abeabd5fbf9f8b016261c857d50d7888dab95f825dc068ea63d41ae150d9b8L454) it was not consistent with the code, but [here](https://github.com/adafruit/Adafruit-GFX-Library/compare/master...omicronns:Adafruit-GFX-Library:master?expand=1#diff-20abeabd5fbf9f8b016261c857d50d7888dab95f825dc068ea63d41ae150d9b8L472) it was, so I'm not sure if this fix is correct, but it seemd odd that direction register would be different size than access register.