### PR TITLE
Allow using ATtiny84

### DIFF
--- a/Adafruit_GrayOLED.cpp
+++ b/Adafruit_GrayOLED.cpp
@@ -15,7 +15,8 @@
  *
  */
 
-#if !defined(__AVR_ATtiny85__) // Not for ATtiny, at all
+// Not for ATtiny, at all
+#if !defined(__AVR_ATtiny85__) && !defined(__AVR_ATtiny84__)
 
 #include "Adafruit_GrayOLED.h"
 #include <Adafruit_GFX.h>

--- a/Adafruit_GrayOLED.h
+++ b/Adafruit_GrayOLED.h
@@ -24,7 +24,8 @@
 #ifndef _Adafruit_GRAYOLED_H_
 #define _Adafruit_GRAYOLED_H_
 
-#if !defined(__AVR_ATtiny85__) // Not for ATtiny, at all
+// Not for ATtiny, at all
+#if !defined(__AVR_ATtiny85__) && !defined(__AVR_ATtiny84__)
 
 #include <Adafruit_GFX.h>
 #include <Adafruit_I2CDevice.h>
@@ -96,5 +97,5 @@ private:
   TwoWire *_theWire = NULL; ///< The underlying hardware I2C
 };
 
-#endif // end __AVR_ATtiny85__
+#endif // end __AVR_ATtiny85__ __AVR_ATtiny84__
 #endif // _Adafruit_GrayOLED_H_

--- a/Adafruit_SPITFT.cpp
+++ b/Adafruit_SPITFT.cpp
@@ -31,7 +31,8 @@
  * BSD license, all text here must be included in any redistribution.
  */
 
-#if !defined(__AVR_ATtiny85__) // Not for ATtiny, at all
+// Not for ATtiny, at all
+#if !defined(__AVR_ATtiny85__) && !defined(__AVR_ATtiny84__)
 
 #include "Adafruit_SPITFT.h"
 
@@ -2558,4 +2559,4 @@ inline void Adafruit_SPITFT::TFT_RD_LOW(void) {
 #endif // end !USE_FAST_PINIO
 }
 
-#endif // end __AVR_ATtiny85__
+#endif // end __AVR_ATtiny85__ __AVR_ATtiny84__

--- a/Adafruit_SPITFT.h
+++ b/Adafruit_SPITFT.h
@@ -20,7 +20,8 @@
 #ifndef _ADAFRUIT_SPITFT_H_
 #define _ADAFRUIT_SPITFT_H_
 
-#if !defined(__AVR_ATtiny85__) // Not for ATtiny, at all
+// Not for ATtiny, at all
+#if !defined(__AVR_ATtiny85__) && !defined(__AVR_ATtiny84__)
 
 #include "Adafruit_GFX.h"
 #include <SPI.h>
@@ -526,5 +527,5 @@ protected:
   uint32_t _freq = 0; ///< Dummy var to keep subclasses happy
 };
 
-#endif // end __AVR_ATtiny85__
+#endif // end __AVR_ATtiny85__ __AVR_ATtiny84__
 #endif // end _ADAFRUIT_SPITFT_H_


### PR DESCRIPTION
This library also works with an ATtiny84, but only checking for ATtiny85 restricts its usage.

I came across this restriction when trying to use [Adafruit LED Backpack](https://github.com/adafruit/Adafruit_LED_Backpack) with an ATtiny84.