### PR TITLE
For ESP-IDF builds use arduino-esp32 instead of arduino dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,6 @@ cmake_minimum_required(VERSION 3.5)
 
 idf_component_register(SRCS "Adafruit_GFX.cpp" "Adafruit_GrayOLED.cpp" "Adafruit_SPITFT.cpp" "glcdfont.c"
                        INCLUDE_DIRS "."
-                       REQUIRES arduino Adafruit_BusIO)
+                       REQUIRES arduino-esp32 Adafruit_BusIO)
 
 project(Adafruit-GFX-Library)


### PR DESCRIPTION
This is the [documented way](https://github.com/espressif/arduino-esp32/blob/b2e67ca2785bf666f1715978bb51ebee8be62dab/docs/en/esp-idf_component.rst?plain=1#L257) to reference the `arduino-esp32` component. I believe you must reference it this way to use the [version in IDF component manager](https://components.espressif.com/components/espressif/arduino-esp32/versions/3.0.3).

Similar PR for BusIO: https://github.com/adafruit/Adafruit_BusIO/pull/131