### PR TITLE
Add new method drawBitmapFast with better performance

### DIFF
--- a/Adafruit_SPITFT.cpp
+++ b/Adafruit_SPITFT.cpp
@@ -976,15 +976,13 @@ void Adafruit_SPITFT::drawBitmapFast(int16_t x, int16_t y, uint8_t *bitmap, int1
     uint8_t b = 0;
     int16_t wclip = w;
     int16_t hclip = h;
-    int16_t wmax = _width - x;
-    int16_t hmax = _height - y;
     
     // Clipped width and height
-    if (w > wmax)
-      wclip = wmax;
+    if (w > (_width - x))
+      wclip = _width - x;
     
-    if (h > hmax)
-      hclip = hmax;
+    if (h > (_height - y))
+      hclip = _height - y;
     
     startWrite();
     setAddrWindow(x, y, wclip, hclip);

--- a/Adafruit_SPITFT.cpp
+++ b/Adafruit_SPITFT.cpp
@@ -965,7 +965,7 @@ void Adafruit_SPITFT::writePixel(int16_t x, int16_t y, uint16_t color) {
     @param    bg 16-bit 5-6-5 Color to draw background with
 */
 /**************************************************************************/
-void Adafruit_SPITFT::drawBitmapAutoIncrement(int16_t x, int16_t y, uint8_t *bitmap, int16_t w,
+void Adafruit_SPITFT::drawBitmapFast(int16_t x, int16_t y, uint8_t *bitmap, int16_t w,
                               int16_t h, uint16_t color, uint16_t bg) {
 
   int16_t byteWidth = (w + 7) / 8; // Bitmap scanline pad = whole byte

--- a/Adafruit_SPITFT.cpp
+++ b/Adafruit_SPITFT.cpp
@@ -976,13 +976,15 @@ void Adafruit_SPITFT::drawBitmapFast(int16_t x, int16_t y, uint8_t *bitmap, int1
     uint8_t b = 0;
     int16_t wclip = w;
     int16_t hclip = h;
+    int16_t wmax = _width - x;
+    int16_t hmax = _height - y;
     
     // Clipped width and height
-    if (((x + w - _width) > 0) && (x < _width))
-      wclip = _width - x;
+    if (w > wmax)
+      wclip = wmax;
     
-    if (((y + h - _height) > 0) && (y < _height))
-      hclip = _height - y;
+    if (h > hmax)
+      hclip = hmax;
     
     startWrite();
     setAddrWindow(x, y, wclip, hclip);

--- a/Adafruit_SPITFT.cpp
+++ b/Adafruit_SPITFT.cpp
@@ -954,8 +954,11 @@ void Adafruit_SPITFT::writePixel(int16_t x, int16_t y, uint16_t color) {
 /*!
    @brief      Draw a RAM-resident 1-bit image at the specified (x,y) position,
    using the specified foreground (for set bits) and background (unset bits)
-   colors. This is a clone of the Adafruit_GFX method but much faster since it
-   uses the address auto-increment of the TFT.
+   colors. This is a clone of the Adafruit_GFX method but without a call to 
+   setAddrWindow for each pixel. Instead the window is setup once, and then
+   all pixels are written. This relise on the address auto-increment of the TFT.
+   Note that the image must fit within the display bounds, otherwise nothing is
+   done.
     @param    x   Top left corner x coordinate
     @param    y   Top left corner y coordinate
     @param    bitmap  byte array with monochrome bitmap
@@ -972,8 +975,8 @@ void Adafruit_SPITFT::drawBitmapFast(int16_t x, int16_t y, uint8_t *bitmap, int1
   uint8_t b = 0;
   
   if ((x >= 0) && (x < (_width - w + 1)) && (y >= 0) && (y < (_height - h + 1))) {
-    setAddrWindow(x, y, w, h);
     startWrite();
+    setAddrWindow(x, y, w, h);
     for (int16_t j = 0; j < h; j++, y++) {
       for (int16_t i = 0; i < w; i++) {
         if (i & 7)

--- a/Adafruit_SPITFT.cpp
+++ b/Adafruit_SPITFT.cpp
@@ -956,7 +956,7 @@ void Adafruit_SPITFT::writePixel(int16_t x, int16_t y, uint16_t color) {
    using the specified foreground (for set bits) and background (unset bits)
    colors. This is a clone of the Adafruit_GFX method but without a call to 
    setAddrWindow for each pixel. Instead the window is setup once, and then
-   all pixels are written. This relise on the address auto-increment of the TFT.
+   all pixels are written. This relies on the address auto-increment of the TFT.
    Note that the image must fit within the display bounds, otherwise nothing is
    done.
     @param    x   Top left corner x coordinate

--- a/Adafruit_SPITFT.cpp
+++ b/Adafruit_SPITFT.cpp
@@ -972,10 +972,8 @@ void Adafruit_SPITFT::drawBitmapFast(int16_t x, int16_t y, uint8_t *bitmap, int1
 
   // Sanity check of X and Y position
   if ((x >= 0) && (x < _width) && (y >= 0) && (y < _height)) {
-    
     int16_t byteWidth = (w + 7) / 8; // Bitmap scanline pad = whole byte
     uint8_t b = 0;
-    
     int16_t wclip = w;
     int16_t hclip = h;
     

--- a/Adafruit_SPITFT.cpp
+++ b/Adafruit_SPITFT.cpp
@@ -950,6 +950,43 @@ void Adafruit_SPITFT::writePixel(int16_t x, int16_t y, uint16_t color) {
   }
 }
 
+/**************************************************************************/
+/*!
+   @brief      Draw a RAM-resident 1-bit image at the specified (x,y) position,
+   using the specified foreground (for set bits) and background (unset bits)
+   colors. This is a clone of the Adafruit_GFX method but much faster since it
+   uses the address auto-increment of the TFT.
+    @param    x   Top left corner x coordinate
+    @param    y   Top left corner y coordinate
+    @param    bitmap  byte array with monochrome bitmap
+    @param    w   Width of bitmap in pixels
+    @param    h   Height of bitmap in pixels
+    @param    color 16-bit 5-6-5 Color to draw pixels with
+    @param    bg 16-bit 5-6-5 Color to draw background with
+*/
+/**************************************************************************/
+void Adafruit_SPITFT::drawBitmapAutoIncrement(int16_t x, int16_t y, uint8_t *bitmap, int16_t w,
+                              int16_t h, uint16_t color, uint16_t bg) {
+
+  int16_t byteWidth = (w + 7) / 8; // Bitmap scanline pad = whole byte
+  uint8_t b = 0;
+  
+  if ((x >= 0) && (x < (_width - w + 1)) && (y >= 0) && (y < (_height - h + 1))) {
+    setAddrWindow(x, y, w, h);
+    startWrite();
+    for (int16_t j = 0; j < h; j++, y++) {
+      for (int16_t i = 0; i < w; i++) {
+        if (i & 7)
+          b <<= 1;
+        else
+          b = bitmap[j * byteWidth + i / 8];
+        SPI_WRITE16((b & 0x80) ? color : bg);
+      }
+    }
+    endWrite();
+  }
+}
+
 /*!
     @brief  Swap bytes in an array of pixels; converts little-to-big or
             big-to-little endian. Used by writePixels() below in some

--- a/Adafruit_SPITFT.cpp
+++ b/Adafruit_SPITFT.cpp
@@ -969,34 +969,34 @@ void Adafruit_SPITFT::writePixel(int16_t x, int16_t y, uint16_t color) {
 /**************************************************************************/
 void Adafruit_SPITFT::drawBitmapFast(int16_t x, int16_t y, uint8_t *bitmap, int16_t w,
                               int16_t h, uint16_t color, uint16_t bg) {
-
   // Sanity check of X and Y position
-  if ((x >= 0) && (x < _width) && (y >= 0) && (y < _height)) {
-    int16_t byteWidth = (w + 7) / 8; // Bitmap scanline pad = whole byte
-    uint8_t b = 0;
-    int16_t wclip = w;
-    int16_t hclip = h;
+  if ((x < 0) || (x >= _width) || (y < 0) || (y >= _height))
+    return;
     
-    // Clipped width and height
-    if (w > (_width - x))
-      wclip = _width - x;
-    
-    if (h > (_height - y))
-      hclip = _height - y;
-    
-    startWrite();
-    setAddrWindow(x, y, wclip, hclip);
-    for (int16_t j = 0; j < hclip; j++, y++) {
-      for (int16_t i = 0; i < wclip; i++) {
-        if (i & 7)
-          b <<= 1;
-        else
-          b = bitmap[j * byteWidth + i / 8];
-        SPI_WRITE16((b & 0x80) ? color : bg);
-      }
+  int16_t byteWidth = (w + 7) / 8; // Bitmap scanline pad = whole byte
+  uint8_t b = 0;
+  int16_t wclip = w;
+  int16_t hclip = h;
+  
+  // Clipped width and height
+  if (w > (_width - x))
+    wclip = _width - x;
+  
+  if (h > (_height - y))
+    hclip = _height - y;
+  
+  startWrite();
+  setAddrWindow(x, y, wclip, hclip);
+  for (int16_t j = 0; j < hclip; j++, y++) {
+    for (int16_t i = 0; i < wclip; i++) {
+      if (i & 7)
+        b <<= 1;
+      else
+        b = bitmap[j * byteWidth + i / 8];
+      SPI_WRITE16((b & 0x80) ? color : bg);
     }
-    endWrite();
   }
+  endWrite();
 }
 
 /*!

--- a/Adafruit_SPITFT.h
+++ b/Adafruit_SPITFT.h
@@ -216,8 +216,8 @@ public:
   // before ending the transaction. It's more efficient than starting a
   // transaction every time.
   void writePixel(int16_t x, int16_t y, uint16_t color);
-  void drawBitmapAutoIncrement(int16_t x, int16_t y, uint8_t *bitmap, 
-							int16_t w, int16_t h, uint16_t color, uint16_t bg);
+  void drawBitmapFast(int16_t x, int16_t y, uint8_t *bitmap, 
+                      int16_t w, int16_t h, uint16_t color, uint16_t bg);
   
   void writePixels(uint16_t *colors, uint32_t len, bool block = true,
                    bool bigEndian = false);

--- a/Adafruit_SPITFT.h
+++ b/Adafruit_SPITFT.h
@@ -218,7 +218,6 @@ public:
   void writePixel(int16_t x, int16_t y, uint16_t color);
   void drawBitmapFast(int16_t x, int16_t y, uint8_t *bitmap, 
                       int16_t w, int16_t h, uint16_t color, uint16_t bg);
-  
   void writePixels(uint16_t *colors, uint32_t len, bool block = true,
                    bool bigEndian = false);
   void writeColor(uint16_t color, uint32_t len);

--- a/Adafruit_SPITFT.h
+++ b/Adafruit_SPITFT.h
@@ -216,6 +216,9 @@ public:
   // before ending the transaction. It's more efficient than starting a
   // transaction every time.
   void writePixel(int16_t x, int16_t y, uint16_t color);
+  void drawBitmapAutoIncrement(int16_t x, int16_t y, uint8_t *bitmap, 
+							int16_t w, int16_t h, uint16_t color, uint16_t bg);
+  
   void writePixels(uint16_t *colors, uint32_t len, bool block = true,
                    bool bigEndian = false);
   void writeColor(uint16_t color, uint32_t len);


### PR DESCRIPTION
Added a new method drawBitmapFast in Adafruit_SPITFT which is esentially a copy of the Adafruit_GFX drawBitmap but with much better performance. This is achieved by setting up the address window for the whole image; not for each pixel.

Performance is about 8 times higher.

The method applies clipping so that only the portion of the image that is within the display bounds is written.

Code has been tested with various X/Y offsets to verify that clipping is properly applied.

Note that I was forced to create a copy because of the stated limitations of Adafruit_GFX. I would rather change the Adafruit_GFX method, but that would require adding some abstract methods (e.g. for setting up the window) which would break backward compatibility.

This change is related to this issue: https://github.com/adafruit/Adafruit-GFX-Library/issues/415