### PR TITLE
Added drawEllipse and fillEllipse functions

### DIFF
--- a/Adafruit_GFX.cpp
+++ b/Adafruit_GFX.cpp
@@ -350,33 +350,31 @@ void Adafruit_GFX::drawLine(int16_t x0, int16_t y0, int16_t x1, int16_t y1,
    @brief    Draw an ellipse outline
     @param    x0   Center-point x coordinate
     @param    y0   Center-point y coordinate
-    @param    rw   Horizontal width of ellipse
-    @param    rh   Vertical height of ellipse
+    @param    rw   Horizontal radius of ellipse
+    @param    rh   Vertical radius of ellipse
     @param    color 16-bit 5-6-5 Color to draw with
 */
 /**************************************************************************/
 void Adafruit_GFX::drawEllipse(int16_t x0, int16_t y0, int16_t rw, int16_t rh,
-                              uint16_t color) {
+                               uint16_t color) {
 #if defined(ESP8266)
   yield();
 #endif
   // Bresenham's ellipse algorithm
-                            
   int16_t x = 0, y = rh;
   int32_t rw2 = rw * rw, rh2 = rh * rh;
   int32_t twoRw2 = 2 * rw2, twoRh2 = 2 * rh2;
 
-  int32_t decision = rh2 - (rw2 * rh) + (rw2/4);
+  int32_t decision = rh2 - (rw2 * rh) + (rw2 / 4);
 
   startWrite();
 
-  //region 1
+  // region 1
   while ((twoRh2 * x) < (twoRw2 * y)) {
     writePixel(x0 + x, y0 + y, color);
     writePixel(x0 - x, y0 + y, color);
     writePixel(x0 + x, y0 - y, color);
     writePixel(x0 - x, y0 - y, color);
-
     x++;
     if (decision < 0) {
       decision += rh2 + (twoRh2 * x);
@@ -386,14 +384,14 @@ void Adafruit_GFX::drawEllipse(int16_t x0, int16_t y0, int16_t rw, int16_t rh,
     }
   }
 
-  //region 2
-  decision = ((rh2 * (2 * x + 1) * (2 * x + 1)) >> 2) + (rw2 * (y - 1) * (y - 1)) - (rw2 * rh2);
+  // region 2
+  decision = ((rh2 * (2 * x + 1) * (2 * x + 1)) >> 2) +
+             (rw2 * (y - 1) * (y - 1)) - (rw2 * rh2);
   while (y >= 0) {
     writePixel(x0 + x, y0 + y, color);
     writePixel(x0 - x, y0 + y, color);
     writePixel(x0 + x, y0 - y, color);
     writePixel(x0 - x, y0 - y, color);
-
     y--;
     if (decision > 0) {
       decision += rw2 - (twoRw2 * y);
@@ -411,31 +409,30 @@ void Adafruit_GFX::drawEllipse(int16_t x0, int16_t y0, int16_t rw, int16_t rh,
    @brief    Draw an ellipse with filled colour
     @param    x0   Center-point x coordinate
     @param    y0   Center-point y coordinate
-    @param    rw   Horizontal width of ellipse
-    @param    rh   Vertical height of ellipse
+    @param    rw   Horizontal radius of ellipse
+    @param    rh   Vertical radius of ellipse
     @param    color 16-bit 5-6-5 Color to draw with
 */
 /**************************************************************************/
 void Adafruit_GFX::fillEllipse(int16_t x0, int16_t y0, int16_t rw, int16_t rh,
-                              uint16_t color) {
+                               uint16_t color) {
 #if defined(ESP8266)
   yield();
 #endif
   // Bresenham's ellipse algorithm
-                            
   int16_t x = 0, y = rh;
   int32_t rw2 = rw * rw, rh2 = rh * rh;
   int32_t twoRw2 = 2 * rw2, twoRh2 = 2 * rh2;
 
-  int32_t decision = rh2 - (rw2 * rh) + (rw2/4);
+  int32_t decision = rh2 - (rw2 * rh) + (rw2 / 4);
 
   startWrite();
 
-  //region 1
+  // region 1
   while ((twoRh2 * x) < (twoRw2 * y)) {
     drawFastHLine(x0 - x, y0 + y, 2 * x + 1, color);
     drawFastHLine(x0 - x, y0 - y, 2 * x + 1, color);
-    
+
     x++;
     if (decision < 0) {
       decision += rh2 + (twoRh2 * x);
@@ -445,13 +442,13 @@ void Adafruit_GFX::fillEllipse(int16_t x0, int16_t y0, int16_t rw, int16_t rh,
     }
   }
 
-  //region 2
-  decision = ((rh2 * (2 * x + 1) * (2 * x + 1)) >> 2) + (rw2 * (y - 1) * (y - 1)) - (rw2 * rh2);
+  // region 2
+  decision = ((rh2 * (2 * x + 1) * (2 * x + 1)) >> 2) +
+             (rw2 * (y - 1) * (y - 1)) - (rw2 * rh2);
   while (y >= 0) {
-
     drawFastHLine(x0 - x, y0 + y, 2 * x + 1, color);
     drawFastHLine(x0 - x, y0 - y, 2 * x + 1, color);
-    
+
     y--;
     if (decision > 0) {
       decision += rw2 - (twoRw2 * y);

--- a/Adafruit_GFX.cpp
+++ b/Adafruit_GFX.cpp
@@ -347,6 +347,125 @@ void Adafruit_GFX::drawLine(int16_t x0, int16_t y0, int16_t x1, int16_t y1,
 
 /**************************************************************************/
 /*!
+   @brief    Draw an ellipse outline
+    @param    x0   Center-point x coordinate
+    @param    y0   Center-point y coordinate
+    @param    rw   Horizontal width of ellipse
+    @param    rh   Vertical height of ellipse
+    @param    color 16-bit 5-6-5 Color to draw with
+*/
+/**************************************************************************/
+void Adafruit_GFX::drawEllipse(int16_t x0, int16_t y0, int16_t rw, int16_t rh,
+                              uint16_t color) {
+#if defined(ESP8266)
+  yield();
+#endif
+  // Bresenham's ellipse algorithm
+                            
+  int16_t x = 0, y = rh;
+  int32_t rw2 = rw * rw, rh2 = rh * rh;
+  int32_t twoRw2 = 2 * rw2, twoRh2 = 2 * rh2;
+
+  int32_t decision = rh2 - (rw2 * rh) + (rw2/4);
+
+  startWrite();
+
+  //region 1
+  while ((twoRh2 * x) < (twoRw2 * y)) {
+    writePixel(x0 + x, y0 + y, color);
+    writePixel(x0 - x, y0 + y, color);
+    writePixel(x0 + x, y0 - y, color);
+    writePixel(x0 - x, y0 - y, color);
+
+    x++;
+    if (decision < 0) {
+      decision += rh2 + (twoRh2 * x);
+    } else {
+      decision += rh2 + (twoRh2 * x) - (twoRw2 * y);
+      y--;
+    }
+  }
+
+  //region 2
+  decision = ((rh2 * (2 * x + 1) * (2 * x + 1)) >> 2) + (rw2 * (y - 1) * (y - 1)) - (rw2 * rh2);
+  while (y >= 0) {
+    writePixel(x0 + x, y0 + y, color);
+    writePixel(x0 - x, y0 + y, color);
+    writePixel(x0 + x, y0 - y, color);
+    writePixel(x0 - x, y0 - y, color);
+
+    y--;
+    if (decision > 0) {
+      decision += rw2 - (twoRw2 * y);
+    } else {
+      decision += rw2 + (twoRh2 * x) - (twoRw2 * y);
+      x++;
+    }
+  }
+
+  endWrite();
+}
+
+/**************************************************************************/
+/*!
+   @brief    Draw an ellipse with filled colour
+    @param    x0   Center-point x coordinate
+    @param    y0   Center-point y coordinate
+    @param    rw   Horizontal width of ellipse
+    @param    rh   Vertical height of ellipse
+    @param    color 16-bit 5-6-5 Color to draw with
+*/
+/**************************************************************************/
+void Adafruit_GFX::fillEllipse(int16_t x0, int16_t y0, int16_t rw, int16_t rh,
+                              uint16_t color) {
+#if defined(ESP8266)
+  yield();
+#endif
+  // Bresenham's ellipse algorithm
+                            
+  int16_t x = 0, y = rh;
+  int32_t rw2 = rw * rw, rh2 = rh * rh;
+  int32_t twoRw2 = 2 * rw2, twoRh2 = 2 * rh2;
+
+  int32_t decision = rh2 - (rw2 * rh) + (rw2/4);
+
+  startWrite();
+
+  //region 1
+  while ((twoRh2 * x) < (twoRw2 * y)) {
+    drawFastHLine(x0 - x, y0 + y, 2 * x + 1, color);
+    drawFastHLine(x0 - x, y0 - y, 2 * x + 1, color);
+    
+    x++;
+    if (decision < 0) {
+      decision += rh2 + (twoRh2 * x);
+    } else {
+      decision += rh2 + (twoRh2 * x) - (twoRw2 * y);
+      y--;
+    }
+  }
+
+  //region 2
+  decision = ((rh2 * (2 * x + 1) * (2 * x + 1)) >> 2) + (rw2 * (y - 1) * (y - 1)) - (rw2 * rh2);
+  while (y >= 0) {
+
+    drawFastHLine(x0 - x, y0 + y, 2 * x + 1, color);
+    drawFastHLine(x0 - x, y0 - y, 2 * x + 1, color);
+    
+    y--;
+    if (decision > 0) {
+      decision += rw2 - (twoRw2 * y);
+    } else {
+      decision += rw2 + (twoRh2 * x) - (twoRw2 * y);
+      x++;
+    }
+  }
+
+  endWrite();
+}
+
+/**************************************************************************/
+/*!
    @brief    Draw a circle outline
     @param    x0   Center-point x coordinate
     @param    y0   Center-point y coordinate

--- a/Adafruit_GFX.h
+++ b/Adafruit_GFX.h
@@ -73,6 +73,8 @@ public:
   void fillCircle(int16_t x0, int16_t y0, int16_t r, uint16_t color);
   void fillCircleHelper(int16_t x0, int16_t y0, int16_t r, uint8_t cornername,
                         int16_t delta, uint16_t color);
+  void drawEllipse(int16_t x0, int16_t y0, int16_t rw, int16_t rh, uint16_t color);
+  void fillEllipse(int16_t x0, int16_t y0, int16_t rw, int16_t rh, uint16_t color);
   void drawTriangle(int16_t x0, int16_t y0, int16_t x1, int16_t y1, int16_t x2,
                     int16_t y2, uint16_t color);
   void fillTriangle(int16_t x0, int16_t y0, int16_t x1, int16_t y1, int16_t x2,

--- a/Adafruit_GFX.h
+++ b/Adafruit_GFX.h
@@ -73,8 +73,10 @@ public:
   void fillCircle(int16_t x0, int16_t y0, int16_t r, uint16_t color);
   void fillCircleHelper(int16_t x0, int16_t y0, int16_t r, uint8_t cornername,
                         int16_t delta, uint16_t color);
-  void drawEllipse(int16_t x0, int16_t y0, int16_t rw, int16_t rh, uint16_t color);
-  void fillEllipse(int16_t x0, int16_t y0, int16_t rw, int16_t rh, uint16_t color);
+  void drawEllipse(int16_t x0, int16_t y0, int16_t rw, int16_t rh,
+                   uint16_t color);
+  void fillEllipse(int16_t x0, int16_t y0, int16_t rw, int16_t rh,
+                   uint16_t color);
   void drawTriangle(int16_t x0, int16_t y0, int16_t x1, int16_t y1, int16_t x2,
                     int16_t y2, uint16_t color);
   void fillTriangle(int16_t x0, int16_t y0, int16_t x1, int16_t y1, int16_t x2,


### PR DESCRIPTION
This change adds both drawEllipse and fillEllipse functions using Bresenham's algorithm to the GFX library. The only modifications are the inclusion of both of these functions in the Adafruit_GFX.cpp file and their definitions in the associated header file.

Closes #474 