### PR TITLE
Optimise fillEllipse function.  ~36% faster

### DIFF
--- a/Adafruit_GFX.cpp
+++ b/Adafruit_GFX.cpp
@@ -444,7 +444,6 @@ void Adafruit_GFX::fillEllipse(int16_t x0, int16_t y0, int16_t rw, int16_t rh,
   // region 2
   decision = ((rh2 * (2 * x + 1) * (2 * x + 1)) >> 2) +
              (rw2 * (y - 1) * (y - 1)) - (rw2 * rh2);
-  bool doneY = false;
   while (y >= 0) {
     drawFastHLine(x0 - x, y0 + y, 2 * x + 1, color);
     drawFastHLine(x0 - x, y0 - y, 2 * x + 1, color);
@@ -455,7 +454,6 @@ void Adafruit_GFX::fillEllipse(int16_t x0, int16_t y0, int16_t rw, int16_t rh,
     } else {
       decision += rw2 + (twoRh2 * x) - (twoRw2 * y);
       x++;
-      doneY = false;
     }
   }
 


### PR DESCRIPTION
Made a change to the fillEllipse function so that the horizontal lines are only drawn when they're at their longest. This eliminates instances of a longer horizontal line being drawn over a shorter one by only drawing the longer line.

This results in a 36% speed increase when tested on drawing 1000 filled ellipses on an ESP32 with a SH110x display. 

No known limitations, the only changes made are to the Adafruit_GFX.cpp file. I just moved the drawLine calls so that they're only called when we move to the next line vertically.