### PR TITLE
Update fillCircleHelper (and related methods) to be consistent with drawCircleHelper

### DIFF
--- a/Adafruit_GFX.cpp
+++ b/Adafruit_GFX.cpp
@@ -514,7 +514,7 @@ void Adafruit_GFX::drawCircle(int16_t x0, int16_t y0, int16_t r,
     @param    x0   Center-point x coordinate
     @param    y0   Center-point y coordinate
     @param    r   Radius of circle
-    @param    cornername  Mask bit #1 or bit #2 to indicate which quarters of
+    @param    cornername  Mask bit #1, #2, #4, and #8 to indicate which quarters of
    the circle we're doing
     @param    color 16-bit 5-6-5 Color to draw with
 */
@@ -578,7 +578,8 @@ void Adafruit_GFX::fillCircle(int16_t x0, int16_t y0, int16_t r,
     @param  x0       Center-point x coordinate
     @param  y0       Center-point y coordinate
     @param  r        Radius of circle
-    @param  corners  Mask bits indicating which quarters we're doing
+    @param  corners  Mask bit #1, #2, #4, and #8 to indicate which quarters of
+   the circle we're doing
     @param  delta    Offset from center-point, used for round-rects
     @param  color    16-bit 5-6-5 Color to fill with
 */


### PR DESCRIPTION
The method fillCircleHelper is inconsistent with the drawCircleHelper method. The brief for fillCircleHelper suggests it can render quarter circle segments while only capable of rendering half circles, while the brief for drawCircleHelper inaccurately states it only supports two mask bits while actually supporting four, one for each quadrant. 

This PR addresses that by modifying fillCircleHelper to draw each corner independently. This makes the fillCircleHelper implementation consistent with drawCircleHelper, at the cost of fillCircleHelper being slightly less efficient (four calls to writeFastVLine instead of two). The two dependent methods, fillCircle and fillRoundRect, have also been updated to correctly use this new implementation. The briefs for fillCircleHelper and drawCircleHelper have been updated to more accurately reflect their functionality. 