### PR TITLE
Modified fillEllipse to use writeFastHLine instead of drawFastHLine

### DIFF
--- a/Adafruit_GFX.cpp
+++ b/Adafruit_GFX.cpp
@@ -435,8 +435,8 @@ void Adafruit_GFX::fillEllipse(int16_t x0, int16_t y0, int16_t rw, int16_t rh,
       decision += rh2 + (twoRh2 * x);
     } else {
       decision += rh2 + (twoRh2 * x) - (twoRw2 * y);
-      drawFastHLine(x0 - (x - 1), y0 + y, 2 * (x - 1) + 1, color);
-      drawFastHLine(x0 - (x - 1), y0 - y, 2 * (x - 1) + 1, color);
+      writeFastHLine(x0 - (x - 1), y0 + y, 2 * (x - 1) + 1, color);
+      writeFastHLine(x0 - (x - 1), y0 - y, 2 * (x - 1) + 1, color);
       y--;
     }
   }
@@ -445,8 +445,8 @@ void Adafruit_GFX::fillEllipse(int16_t x0, int16_t y0, int16_t rw, int16_t rh,
   decision = ((rh2 * (2 * x + 1) * (2 * x + 1)) >> 2) +
              (rw2 * (y - 1) * (y - 1)) - (rw2 * rh2);
   while (y >= 0) {
-    drawFastHLine(x0 - x, y0 + y, 2 * x + 1, color);
-    drawFastHLine(x0 - x, y0 - y, 2 * x + 1, color);
+    writeFastHLine(x0 - x, y0 + y, 2 * x + 1, color);
+    writeFastHLine(x0 - x, y0 - y, 2 * x + 1, color);
 
     y--;
     if (decision > 0) {


### PR DESCRIPTION
This is a fix for issue #492

I have changed the fillEllipse function to use writeFastHLine instead of drawFastHline. This avoids a deadlock situation with nested startWrite calls.

This follows the same pattern as fillCircle and fillCircleHelper which use writeFast functions and not drawFast functions.