### PR TITLE
Feature/pentagram&hexagon

### DIFF
--- a/Adafruit_GFX.cpp
+++ b/Adafruit_GFX.cpp
@@ -722,6 +722,64 @@ void Adafruit_GFX::drawTriangle(int16_t x0, int16_t y0, int16_t x1, int16_t y1,
 
 /**************************************************************************/
 /*!
+   @brief    Draw a regular hexagon outline
+    @param    x0  Center x coordinate
+    @param    y0  Center y coordinate
+    @param    r   Radius (distance from center to vertex)
+    @param    color 16-bit 5-6-5 Color to draw with
+*/
+/**************************************************************************/
+void Adafruit_GFX::drawHexagon(int16_t x0, int16_t y0, int16_t r,
+                               uint16_t color) {
+  // Calculate the 6 vertices of the hexagon
+  // Vertices are at angles: 0°, 60°, 120°, 180°, 240°, 300°
+  int16_t x[6], y[6];
+  
+  for (int i = 0; i < 6; i++) {
+    float angle = 3.14159265359 / 3.0 * i; // 60 degrees in radians
+    x[i] = x0 + r * cos(angle);
+    y[i] = y0 + r * sin(angle);
+  }
+  
+  // Draw lines connecting all vertices
+  for (int i = 0; i < 6; i++) {
+    int next = (i + 1) % 6;
+    drawLine(x[i], y[i], x[next], y[next], color);
+  }
+}
+
+/**************************************************************************/
+/*!
+   @brief    Draw a filled regular hexagon
+    @param    x0  Center x coordinate
+    @param    y0  Center y coordinate
+    @param    r   Radius (distance from center to vertex)
+    @param    color 16-bit 5-6-5 Color to fill with
+*/
+/**************************************************************************/
+void Adafruit_GFX::fillHexagon(int16_t x0, int16_t y0, int16_t r,
+                               uint16_t color) {
+  // Calculate the 6 vertices of the hexagon
+  int16_t x[6], y[6];
+  
+  for (int i = 0; i < 6; i++) {
+    float angle = 3.14159265359 / 3.0 * i; // 60 degrees in radians
+    x[i] = x0 + r * cos(angle);
+    y[i] = y0 + r * sin(angle);
+  }
+  
+  // Fill hexagon by drawing 4 triangles from center
+  // Triangle fan from center to each pair of adjacent vertices
+  fillTriangle(x0, y0, x[0], y[0], x[1], y[1], color);
+  fillTriangle(x0, y0, x[1], y[1], x[2], y[2], color);
+  fillTriangle(x0, y0, x[2], y[2], x[3], y[3], color);
+  fillTriangle(x0, y0, x[3], y[3], x[4], y[4], color);
+  fillTriangle(x0, y0, x[4], y[4], x[5], y[5], color);
+  fillTriangle(x0, y0, x[5], y[5], x[0], y[0], color);
+}
+
+/**************************************************************************/
+/*!
    @brief     Draw a triangle with color-fill
     @param    x0  Vertex #0 x coordinate
     @param    y0  Vertex #0 y coordinate

--- a/Adafruit_GFX.h
+++ b/Adafruit_GFX.h
@@ -81,6 +81,8 @@ public:
                     int16_t y2, uint16_t color);
   void fillTriangle(int16_t x0, int16_t y0, int16_t x1, int16_t y1, int16_t x2,
                     int16_t y2, uint16_t color);
+  void drawHexagon(int16_t x0, int16_t y0, int16_t r, uint16_t color);
+  void fillHexagon(int16_t x0, int16_t y0, int16_t r, uint16_t color);
   void drawRoundRect(int16_t x0, int16_t y0, int16_t w, int16_t h,
                      int16_t radius, uint16_t color);
   


### PR DESCRIPTION
变更范围描述
本PR为 Adafruit_GFX 图形库新增了三个几何图形绘制方法，扩展了库的图形绘制能力：

修改的文件
Adafruit_GFX.h- 添加了三个公共方法声明
Adafruit_GFX.cpp - 添加了三个方法的完整实现
新增方法
drawHexagon(int16_t x0, int16_t y0, int16_t r, uint16_t color)

绘制正六边形的轮廓
计算6个均匀分布的顶点（相邻间隔60°）
通过连接相邻顶点形成六边形边框
fillHexagon(int16_t x0, int16_t y0, int16_t r, uint16_t color)

绘制填充的正六边形
使用三角形扇形填充策略，从中心点向外填充6个三角形
充分利用现有的 fillTriangle() 高效扫描线算法
drawPentagram(int16_t x0, int16_t y0, int16_t radius, uint16_t color)

绘制五角星的轮廓
采用双层顶点设计：5个外层顶点（星尖）+ 5个内层顶点
外层顶点间隔72°，内层半径为外层的0.382倍（黄金比例）
通过交替连接形成经典五角星形状
fillPentagram(int16_t x0, int16_t y0, int16_t radius, uint16_t color)

绘制填充的五角星
继承 drawPentagram 的顶点计算方式
通过填充10个三角形（5对）实现高效填充
设计一致性
API规范：所有新增方法遵循库现有的命名和参数模式，与 drawCircle/fillCircle 和 drawTriangle/fillTriangle 风格一致
数据类型：坐标使用 int16_t，颜色使用 uint16_t，与库标准保持统一
基础函数复用：充分利用现有的 drawLine() 和 fillTriangle() 方法，最小化代码冗余
已知限制
精度限制：顶点坐标通过三角函数计算并转换为整数，小数部分会被截断，造成 < 1 像素的偏差，不影响视觉效果
半径范围：应保持在 int16_t 有效范围内（-32768 到 32767）
旋转功能：当前实现没有包含旋转参数，所有图形都是固定朝向（六边形顶部朝上，五角星顶部朝上）
平台兼容性：所有方法均为与平台无关的通用实现