### PR TITLE
Add 8-bit font generation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Recent Arduino IDE releases include the Library Manager for easy installation. O
 
 - 'Fonts' folder contains bitmap fonts for use with recent (1.1 and later) Adafruit_GFX. To use a font in your Arduino sketch, \#include the corresponding .h file and pass address of GFXfont struct to setFont(). Pass NULL to revert to 'classic' fixed-space bitmap font.
 
-- 'fontconvert' folder contains a command-line tool for converting TTF fonts to Adafruit_GFX header format.
+- 'fontconvert' folder contains a command-line tool for converting TTF fonts to Adafruit_GFX header format. It supports both 7-bit (ASCII) and 8-bit (full 0-255) font generation.
 
 - You can also use [this GFX Font Customiser tool](https://github.com/tchapi/Adafruit-GFX-Font-Customiser) (_web version [here](https://tchapi.github.io/Adafruit-GFX-Font-Customiser/)_) to customize or correct the output from [fontconvert](https://github.com/adafruit/Adafruit-GFX-Library/tree/master/fontconvert), and create fonts with only a subset of characters to optimize size.
 

--- a/fontconvert/fontconvert.c
+++ b/fontconvert/fontconvert.c
@@ -10,10 +10,6 @@ For UNIX-like systems.  Outputs to stdout; redirect to header file, e.g.:
 
 REQUIRES FREETYPE LIBRARY.  www.freetype.org
 
-Currently this only extracts the printable 7-bit ASCII chars of a font.
-Will eventually extend with some int'l chars a la ftGFX, not there yet.
-Keep 7-bit fonts around as an option in that case, more compact.
-
 See notes at end for glyph nomenclature & other tidbits.
 */
 #ifndef ARDUINO
@@ -51,7 +47,7 @@ void enbit(uint8_t value) {
 }
 
 int main(int argc, char *argv[]) {
-  int i, j, err, size, first = ' ', last = '~', bitmapOffset = 0, x, y, byte;
+  int i, j, err, size, first = 32, last = 127, bitmapOffset = 0, x, y, byte;
   char *fontName, c, *ptr;
   FT_Library library;
   FT_Face face;
@@ -66,10 +62,12 @@ int main(int argc, char *argv[]) {
   //   fontconvert [filename] [size] [last char]
   //   fontconvert [filename] [size] [first char] [last char]
   // Unless overridden, default first and last chars are
-  // ' ' (space) and '~', respectively
+  // 32 (space) and 127 (DEL), respectively. For 8b font, use 0 255.
 
   if (argc < 3) {
     fprintf(stderr, "Usage: %s fontfile size [first] [last]\n", argv[0]);
+    fprintf(stderr, "       Default: first=32 last=127 (7b ASCII)\n");
+    fprintf(stderr, "       For 8b font: first=0 last=255\n");
     return 1;
   }
 
@@ -109,7 +107,7 @@ int main(int argc, char *argv[]) {
     ptr = &fontName[strlen(fontName)]; // If none, append
   // Insert font size and 7/8 bit.  fontName was alloc'd w/extra
   // space to allow this, we're not sprintfing into Forbidden Zone.
-  sprintf(ptr, "%dpt%db", size, (last > 127) ? 8 : 7);
+  sprintf(ptr, "%dpt%db", size, (last > 127 || first < 32) ? 8 : 7);
   // Space and punctuation chars in name replaced w/ underscores.
   for (i = 0; (c = fontName[i]); i++) {
     if (isspace(c) || ispunct(c))

--- a/fontconvert/fontconvert_win.md
+++ b/fontconvert/fontconvert_win.md
@@ -79,9 +79,18 @@ This command will, eventually, create a "fontconvert.exe" file inside fontconver
 
 Now that you have an executable file, you can use it to create your own fonts to work with Adafruit GFX lib.
 So, if we suppose that you already have a .ttf file with your favorite fonts, jump to the command prompt and type:
+
+**7-bit font (default, ASCII 32-127):**
 ```
 ./fontconvert yourfonts.ttf 9 > yourfonts9pt7b.h
 ```
+
+**8-bit font (full 0-255 range):**
+```
+./fontconvert yourfonts.ttf 9 0 255 > yourfonts9pt8b.h
+```
+This will generate a font header with all 256 glyphs (0-255). Make sure your font file supports the full range.
+
 You can read more details at: [learn.adafruit](https://learn.adafruit.com/adafruit-gfx-graphics-library/using-fonts).
 
 Taraaaaaammm !! you've just created your new font header file. Put it inside the "Fonts" folder, grab a cup of coffee


### PR DESCRIPTION
Hi!
I added optional 8 bit font support to fontconvert because I needed the full 0 to 255 glyph range for a project, and the tool already had everything needed for it. It just wasn't exposed yet.

## What this change does
- Adds support for generating full 8-bit fonts when the user passes first=0 last=255
- Keeps the default 7-bit ASCII behavior the same
- Updates the filename suffix logic so the output is labeled correctly as 7b or 8b
- Updates the docs with the new usage

## What I changed
- Only the character range handling and the documentation.

## Limitations
If the source TTF does not include certain codepoints, FreeType still outputs empty glyphs. This is the same behavior as before.