### PR TITLE
Add method to draw filled quarter circles

### DIFF
--- a/Adafruit_GFX.cpp
+++ b/Adafruit_GFX.cpp
@@ -628,6 +628,69 @@ void Adafruit_GFX::fillCircleHelper(int16_t x0, int16_t y0, int16_t r,
 
 /**************************************************************************/
 /*!
+    @brief  Quarter-circle drawer with fill.
+    @param  x0       Center-point x coordinate
+    @param  y0       Center-point y coordinate
+    @param  r        Radius of circle
+    @param  corners  Mask bits 0x1, 0x2, 0x4, and 0x8 to indicate which quarters
+                     of the circle to fill: 0x1 = top-left, 0x2 = top-right,
+                     0x4 = bottom-right, 0x8 = bottom-left
+    @param  color    16-bit 5-6-5 Color to fill with
+*/
+/**************************************************************************/
+void Adafruit_GFX::fillCircleHelper(int16_t x0, int16_t y0, int16_t r,
+                                     uint8_t corners, uint16_t color) {
+
+  int16_t f = 1 - r;
+  int16_t ddF_x = 1;
+  int16_t ddF_y = -2 * r;
+  int16_t x = 0;
+  int16_t y = r;
+  int16_t px = x;
+  int16_t py = y;
+
+  if (corners & (0x2 | 0x1))
+    writeFastVLine(x0, y0 - r, r + 1, color);
+  if (corners & (0x8 | 0x4))
+    writeFastVLine(x0, y0, r + 1, color);
+
+  while (x < y) {
+    if (f >= 0) {
+      y--;
+      ddF_y += 2;
+      f += ddF_y;
+    }
+    x++;
+    ddF_x += 2;
+    f += ddF_x;
+
+    if (x < (y + 1)) {
+      if (corners & 0x4)
+        writeFastVLine(x0 + x, y0, y, color);
+      if (corners & 0x2)
+        writeFastVLine(x0 + x, y0 - y, y, color);
+      if (corners & 0x8)
+        writeFastVLine(x0 - x, y0, y, color);
+      if (corners & 0x1)
+        writeFastVLine(x0 - x, y0 - y, y, color);
+    }
+    if (y != py) {
+      if (corners & 0x4)
+        writeFastVLine(x0 + py, y0, px, color);
+      if (corners & 0x2)
+        writeFastVLine(x0 + py, y0 - px, px, color);
+      if (corners & 0x8)
+        writeFastVLine(x0 - py, y0, px, color);
+      if (corners & 0x1)
+        writeFastVLine(x0 - py, y0 - px, px, color);
+      py = y;
+    }
+    px = x;
+  }
+}
+
+/**************************************************************************/
+/*!
    @brief   Draw a rectangle with no fill color
     @param    x   Top left corner x coordinate
     @param    y   Top left corner y coordinate

--- a/Adafruit_GFX.h
+++ b/Adafruit_GFX.h
@@ -73,6 +73,8 @@ public:
   void fillCircle(int16_t x0, int16_t y0, int16_t r, uint16_t color);
   void fillCircleHelper(int16_t x0, int16_t y0, int16_t r, uint8_t cornername,
                         int16_t delta, uint16_t color);
+  void fillCircleHelper(int16_t x0, int16_t y0, int16_t r, uint8_t corners,
+                         uint16_t color);
   void drawEllipse(int16_t x0, int16_t y0, int16_t rw, int16_t rh,
                    uint16_t color);
   void fillEllipse(int16_t x0, int16_t y0, int16_t rw, int16_t rh,


### PR DESCRIPTION
The existing fillCircleHelper method does not allow for the drawing of quarter circles, only half circles. This overload corrects that.