### PR TITLE
fix(GFX_Button): initialize currstate/laststate

### DIFF
--- a/Adafruit_GFX.cpp
+++ b/Adafruit_GFX.cpp
@@ -1806,7 +1806,10 @@ void Adafruit_GFX::invertDisplay(bool i) {
    @brief    Create a simple drawn button UI element
 */
 /**************************************************************************/
-Adafruit_GFX_Button::Adafruit_GFX_Button(void) { _gfx = 0; }
+Adafruit_GFX_Button::Adafruit_GFX_Button(void) {
+  _gfx = 0;
+  currstate = laststate = false;
+}
 
 /**************************************************************************/
 /*!


### PR DESCRIPTION
Fixes #401.

### Problem

`Adafruit_GFX_Button`'s constructor only initializes `_gfx`:

```cpp
Adafruit_GFX_Button::Adafruit_GFX_Button(void) { _gfx = 0; }
```

`currstate`/`laststate` (declared in `Adafruit_GFX.h` with no default member initializer) are left as indeterminate memory. `justPressed()`/`justReleased()` read them:

```cpp
bool Adafruit_GFX_Button::justPressed() { return (currstate && !laststate); }
bool Adafruit_GFX_Button::justReleased() { return (!currstate && laststate); }
```

If either is called before the first `press()` call, the result depends on whatever garbage happened to be on the stack/heap at construction time - a button that was never touched can spuriously report a press or release transition.

### Fix

Initialize both to `false` in the constructor, matching the "not pressed, no prior state" starting condition every other code path already assumes.

### Test plan

No hardware handy, so I verified the logic with a standalone harness modeling the class's exact fields/methods: before the fix, constructing a `Button` over deliberately non-zeroed memory and calling `justPressed()` before any `press()` call can return `true`; after the fix, it correctly returns `false`.

### Disclosure

Generative AI (Claude) was used to help investigate this issue, implement, and verify this fix. All changes were reviewed by me before submission.
