### PR TITLE
Fix GFXfont range reads on big-endian targets

### DIFF
--- a/Adafruit_GFX.cpp
+++ b/Adafruit_GFX.cpp
@@ -1435,7 +1435,7 @@ void Adafruit_GFX::drawChar(int16_t x, int16_t y, unsigned char c,
     // newlines, returns, non-printable characters, etc.  Calling
     // drawChar() directly with 'bad' characters of font may cause mayhem!
 
-    c -= (uint8_t)pgm_read_byte(&gfxFont->first);
+    c -= (uint8_t)pgm_read_word(&gfxFont->first);
     GFXglyph *glyph = pgm_read_glyph_ptr(gfxFont, c);
     uint8_t *bitmap = pgm_read_bitmap_ptr(gfxFont);
 
@@ -1519,8 +1519,8 @@ size_t Adafruit_GFX::write(uint8_t c) {
       cursor_y +=
           (int16_t)textsize_y * (uint8_t)pgm_read_byte(&gfxFont->yAdvance);
     } else if (c != '\r') {
-      uint8_t first = pgm_read_byte(&gfxFont->first);
-      if ((c >= first) && (c <= (uint8_t)pgm_read_byte(&gfxFont->last))) {
+      uint16_t first = pgm_read_word(&gfxFont->first);
+      if ((c >= first) && (c <= pgm_read_word(&gfxFont->last))) {
         GFXglyph *glyph = pgm_read_glyph_ptr(gfxFont, c - first);
         uint8_t w = pgm_read_byte(&glyph->width),
                 h = pgm_read_byte(&glyph->height);
@@ -1635,8 +1635,8 @@ void Adafruit_GFX::charBounds(unsigned char c, int16_t *x, int16_t *y,
       *x = 0;        // Reset x to zero, advance y by one line
       *y += textsize_y * (uint8_t)pgm_read_byte(&gfxFont->yAdvance);
     } else if (c != '\r') { // Not a carriage return; is normal char
-      uint8_t first = pgm_read_byte(&gfxFont->first),
-              last = pgm_read_byte(&gfxFont->last);
+      uint16_t first = pgm_read_word(&gfxFont->first),
+               last = pgm_read_word(&gfxFont->last);
       if ((c >= first) && (c <= last)) { // Char present in this font?
         GFXglyph *glyph = pgm_read_glyph_ptr(gfxFont, c - first);
         uint8_t gw = pgm_read_byte(&glyph->width),


### PR DESCRIPTION
Fixes #490

## Scope

Use word-width program-memory reads for the `GFXfont::first` and `GFXfont::last` fields in the custom-font drawing, writing, and text-bound calculation paths. The fields are declared as `uint16_t`; reading them as bytes breaks the range on big-endian targets.

## Limitations

This keeps the existing 8-bit character API and font format unchanged. It does not add UTF-8 support or refactor the custom-font API.

## Tests

- MinGW GCC 8 with `-Wall -Wextra -Werror` against the real `Adafruit_GFX.cpp`: the endian-aware baseline fixture fails with `0 x 0` bounds, while this change passes with `5 x 7`.
- Linux GCC with AddressSanitizer and UBSan against the same real source: pass (`5 x 7`).
- `git diff --check` and the repository clang-format check: pass.

## Review checklist

- [x] Scope is limited to the reported bug.
- [x] No public API or font-format changes.
- [x] Tested against the real library source.