### PR TITLE
Add library.json with an explicit Adafruit BusIO dependency

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,11 +1,22 @@
 {
   "name": "Adafruit GFX Library",
   "version": "1.12.6",
-  "description": "Adafruit GFX graphics core library, with an explicit Adafruit BusIO dependency declaration for ESPHome's native ESP-IDF library converter (which ignores library.properties depends=)",
+  "description": "Adafruit GFX graphics core library, this is the 'core' class that all our other graphics libraries derive from. Install this library in addition to the display library for your hardware.",
+  "keywords": "display, graphics",
+  "authors": [
+    {
+      "name": "Adafruit",
+      "email": "info@adafruit.com",
+      "maintainer": true
+    }
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/adafruit/Adafruit-GFX-Library.git"
   },
+  "license": "BSD-2-Clause",
+  "frameworks": "arduino",
+  "platforms": "*",
   "dependencies": [
     {
       "owner": "adafruit",

--- a/library.json
+++ b/library.json
@@ -1,0 +1,16 @@
+{
+  "name": "Adafruit GFX Library",
+  "version": "1.12.6",
+  "description": "Adafruit GFX graphics core library, with an explicit Adafruit BusIO dependency declaration for ESPHome's native ESP-IDF library converter (which ignores library.properties depends=)",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/adafruit/Adafruit-GFX-Library.git"
+  },
+  "dependencies": [
+    {
+      "owner": "adafruit",
+      "name": "Adafruit BusIO",
+      "version": "^1.17.0"
+    }
+  ]
+}


### PR DESCRIPTION
## Scope of the change

Adds a `library.json` PlatformIO manifest at the repository root. No source
files are modified — this is a metadata-only change.

Motivation: ESPHome's native ESP-IDF toolchain (ESPHome 2026.5.0 and later,
which builds ESP32 Arduino projects with idf.py instead of PlatformIO)
converts each Arduino library into an ESP-IDF component and only wires
inter-component `REQUIRES` from a `library.json` `dependencies` field. The
`depends=Adafruit BusIO` line in `library.properties` is not consumed, so any
ESPHome project using this library currently fails with:

    Adafruit_GFX.h:12:10: fatal error: Adafruit_I2CDevice.h: No such file or directory

(That include was added in #389 for the same underlying reason — to make
PlatformIO's dependency finder pull in BusIO.)

Since PlatformIO gives `library.json` precedence over `library.properties`
when both exist, the manifest mirrors all existing metadata (description,
authors, license, frameworks, platforms) so the PlatformIO registry listing
loses nothing.

## Known limitations

- The `version` field in `library.json` must be bumped together with
  `library.properties` on release. If your release tooling only touches
  `library.properties`, the two can drift; happy to adjust if you'd prefer a
  different approach.
- Arduino IDE users are unaffected (the Arduino library manager reads only
  `library.properties`).

## Testing

- tested with ESPHome 2026.7 (ESP-IDF 5.5.5, ESP32 Arduino): a project that previously failed with the include error now compiles with this fork as the library source.